### PR TITLE
fix: resp is nil when err is not nil

### DIFF
--- a/cmd/commands/diagnose/networkchecks.go
+++ b/cmd/commands/diagnose/networkchecks.go
@@ -39,7 +39,7 @@ func makeTestRequest(URL string, headers map[string]string) NetworkTestResult {
 		return NetworkTestResult{
 			Passed:       false,
 			Error:        err.Error(),
-			ResponseCode: resp.StatusCode,
+			ResponseCode: 0,
 			URL:          URL,
 		}
 	}


### PR DESCRIPTION
### Description

When the config file does not exist, the req is invalid and resp is nil. Therefore, we cannot access resp.StatusCode.
**TODO**: We need to update the path of config file. In root.go, we use **$HOME/.observe-agent.yaml** as default path. In UI, we use **/etc/observe-agent/observe-agent.yaml**. We need to decide which one to use and update the other one. I do not change this path.