### PR TITLE
fix: OB-31723 add additional host properties to linux config

### DIFF
--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
@@ -27,10 +27,10 @@ service:
   pipelines:
     logs/host_monitoring-file:
       receivers: [filelog/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, batch]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe, count]
 
     logs/host_monitoring-journald:
       receivers: [journald/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, batch]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe, count]

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/metrics.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/metrics.yaml
@@ -25,11 +25,6 @@ receivers:
           system.filesystem.utilization:
             enabled: true
       network:
-        metrics:
-          system.network.conntrack.count:
-            enabled: true
-          system.network.conntrack.max:
-            enabled: true
       paging:
         metrics:
           system.paging.utilization:
@@ -62,5 +57,5 @@ service:
   pipelines:
     metrics/host_monitoring:
       receivers: [hostmetrics/host-monitoring]
-      processors: [memory_limiter, resourcedetection, batch]
+      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe]

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -70,15 +70,36 @@ processors:
   resourcedetection:
     detectors: [env, system]
     system:
-      hostname_sources: ["os"]
+      hostname_sources: ["dns", "os"]
       resource_attributes:
         host.id:
+          enabled: false
+        os.type:
+           enabled: true
+        host.arch:
+          enabled: true
+        host.name:
+          enabled: true
+        host.cpu.vendor.id:
+          enabled: true
+        host.cpu.family:
+          enabled: true
+        host.cpu.model.id:
+          enabled: true
+        host.cpu.model.name:
+          enabled: true
+        host.cpu.stepping:
+          enabled: true
+        host.cpu.cache.l2.size:
+          enabled: true
+        os.description:
           enabled: true
   
   resourcedetection/cloud:
     detectors: ["gcp", "ecs", "ec2", "azure"]
     timeout: 2s
     override: false
+    
 
 exporters:
   otlphttp/observe:


### PR DESCRIPTION
### Description

OB-31723  Switched resource detection to /cloud version to add additional properties to resource on metrics,logs and resource dataset

<img width="1536" alt="image" src="https://github.com/observeinc/observe-agent/assets/103078673/83f441c9-a113-4303-bd6b-8d04a4980d76">


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary