### PR TITLE
feat: update goreleaser task to cut draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Release Version
 
 on:
-  push:
-    # run only against tags
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+    branch:
+      description: "The branch to attempt to build"
+      required: true
+      default: "main"
 
 permissions:
   contents: write
@@ -13,6 +15,7 @@ permissions:
 
 jobs:
   goreleaser:
+    if: contains('["obs-gh-alexlew"]', github.actor)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,6 +69,12 @@ archives:
       - src: "packaging/windows/connections/host_monitoring/*"
         dst: "connections/host_monitoring"
 
+release:
+  github:
+    owner: observeinc
+    name: observe-agent
+  draft: true
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
### Description

OB-32401: Update the release actions to cut a draft release vs. just publishing a tag

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary