### PR TITLE
internal: stop running build on PR

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,7 +1,6 @@
 name: Build Release
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
### Description

OB-9999: Disable build github action on PR

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary