### PR TITLE
feat: add --otel-config flag

### DIFF
--- a/cmd/commands/start/start.go
+++ b/cmd/commands/start/start.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var startCmd = &cobra.Command{
@@ -40,13 +41,14 @@ collector on the current host.`,
 }
 
 func init() {
+	startCmd.PersistentFlags().String("otel-config", "", "Path to additional otel configuration file")
+	viper.BindPFlag("otelConfigFile", startCmd.PersistentFlags().Lookup("otel-config"))
 	cmd.RootCmd.AddCommand(startCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// startCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:

--- a/cmd/config/confighandler.go
+++ b/cmd/config/confighandler.go
@@ -22,6 +22,10 @@ func GetAllOtelConfigFilePaths() ([]string, string, error) {
 			configFilePaths = append(configFilePaths, conn.GetConfigFilePaths()...)
 		}
 	}
+	// Read in otel-config flag and add to paths if set
+	if viper.IsSet("otelConfigFile") {
+		configFilePaths = append(configFilePaths, viper.GetString("otelConfigFile"))
+	}
 	// Generate override file and include path if overrides provided
 	var overridePath string
 	if viper.IsSet("otel_config_overrides") {


### PR DESCRIPTION
### Description

OB-34510 feat: add --otel-config flag to read in additional otel config from file

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary