### PR TITLE
feat: add self_monitoring to docker configs

### DIFF
--- a/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
@@ -1,0 +1,51 @@
+receivers:
+  filestats/agent:
+    include: '/etc/observe-agent/otel-collector.yaml'
+    collection_interval: 240m
+    initial_delay: 60s
+
+  filelog/agent-config: # TODO: Add observe-agent.yaml once we can obfuscate sensitive config fields
+    include: [/etc/observe-agent/otel-collector.yaml]
+    start_at: beginning
+    poll_interval: 5m
+    multiline:
+      line_end_pattern: ENDOFLINEPATTERN
+
+  prometheus/agent:
+    config:
+      scrape_configs:
+        - job_name: 'otelcol'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['0.0.0.0:8888']
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: '.*grpc_io.*'
+              action: drop
+
+  journald/agent:
+    units:
+      - observe-agent
+    priority: info
+
+service:
+  pipelines:
+    metrics/agent-filestats:
+       receivers: [filestats/agent]
+       processors: [resourcedetection, resourcedetection/cloud]
+       exporters: [otlphttp/observe]
+
+    metrics/agent-internal:
+      receivers: [prometheus/agent, count]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [otlphttp/observe]
+
+    logs/agent-journald:
+      receivers: [journald/agent]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [otlphttp/observe, count]
+
+    logs/agent-config:
+       receivers: [filelog/agent-config]
+       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+       exporters: [otlphttp/observe]

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -100,6 +100,11 @@ processors:
     timeout: 2s
     override: false
     
+  filter/count:
+    error_mode: ignore
+    metrics:
+      metric:
+          - 'IsMatch(name, ".*")'
 
 exporters:
   otlphttp/observe:
@@ -111,34 +116,16 @@ exporters:
       queue_size: 100
     retry_on_failure:
       enabled: true
+  
+  debug:
 
 service:
   pipelines:
-    metrics/agent-filestats:
-       receivers: [filestats/agent]
-       processors: [resourcedetection, resourcedetection/cloud]
-       exporters: [otlphttp/observe]
-
-    metrics/agent-internal:
-      receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-      exporters: [otlphttp/observe]
-
     metrics/forward:
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
       exporters: [otlphttp/observe]
 
-    logs/agent-journald:
-      receivers: [journald/agent]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-      exporters: [otlphttp/observe, count]
-
-    logs/agent-config:
-       receivers: [filelog/agent-config]
-       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [otlphttp/observe]
-    
     logs/forward: 
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
@@ -148,6 +135,11 @@ service:
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
       exporters: [otlphttp/observe]
+
+    metrics/count-nooop:
+      receivers: [count]
+      processors: [filter/count]
+      exporters: [debug]
 
   extensions: [health_check, file_storage]
   telemetry:


### PR DESCRIPTION
### Description

OB-34551 feat: split out agent self-monitoring into connection for docker

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary