### PR TITLE
fix: update polling interval for agent config filestats to 5m

### DIFF
--- a/packaging/docker/observe-agent/connections/host_monitoring/host.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/host.yaml
@@ -1,7 +1,7 @@
 receivers:
   filestats/agent:
     include: '/etc/observe-agent/otel-collector.yaml'
-    collection_interval: 240m
+    collection_interval: 5m
     initial_delay: 60s
 
 service:

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/host.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/host.yaml
@@ -1,7 +1,7 @@
 receivers:
   filestats/agent:
     include: '/etc/observe-agent/otel-collector.yaml'
-    collection_interval: 240m
+    collection_interval: 5m
     initial_delay: 60s
 
 service:

--- a/packaging/windows/connections/host_monitoring/host.yaml
+++ b/packaging/windows/connections/host_monitoring/host.yaml
@@ -1,7 +1,7 @@
 receivers:
   filestats/agent:
     include: 'C:\Program Files\Observe\observe-agent\config\otel-collector.yaml'
-    collection_interval: 240m
+    collection_interval: 5m
     initial_delay: 60s
 
 service:


### PR DESCRIPTION
### Description

OB-35568 Update polling interval of host filestats to 5m

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary