### PR TITLE
OB-34960 Decorate k8s Node facets with custom processors

### DIFF
--- a/components/processors/observek8sattributesprocessor/node.go
+++ b/components/processors/observek8sattributesprocessor/node.go
@@ -1,0 +1,5 @@
+package observek8sattributesprocessor
+
+func filterNodeEvents(event K8sEvent) bool {
+	return event.Kind == "Node"
+}

--- a/components/processors/observek8sattributesprocessor/noderoles.go
+++ b/components/processors/observek8sattributesprocessor/noderoles.go
@@ -1,0 +1,51 @@
+package observek8sattributesprocessor
+
+import (
+	"encoding/json"
+
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	NodeRolesAttributeKey = "roles"
+	// labelNodeRolePrefix is a label prefix for node roles
+	labelNodeRolePrefix = "node-role.kubernetes.io/"
+
+	// nodeLabelRole specifies the role of a node
+	nodeLabelRole = "kubernetes.io/role"
+)
+
+var NodeRolesAction = K8sEventProcessorAction{
+	Key:     NodeRolesAttributeKey,
+	ValueFn: getNodeRoles,
+	// Reuse the function to filter events for nodes
+	FilterFn: filterNodeEvents,
+}
+
+// Generates the Node "status" facet. Assumes that objLog is a log from a Node event.
+func getNodeRoles(objLog plog.LogRecord) any {
+	var node v1.Node
+	err := json.Unmarshal([]byte(objLog.Body().AsString()), &node)
+	if err != nil {
+		return "Error while unmarshalling Node"
+	}
+	// based on https://github.com/kubernetes/kubernetes/blob/dbc2b0a5c7acc349ea71a14e49913661eaf708d2/pkg/printers/internalversion/printers.go#L183https://github.com/kubernetes/kubernetes/blob/1e12d92a5179dbfeb455c79dbf9120c8536e5f9c/pkg/printers/internalversion/printers.go#L14875
+	roles := sets.NewString()
+	for k, v := range node.Labels {
+		switch {
+		// The role could be in the key and not in the value
+		case strings.HasPrefix(k, labelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, labelNodeRolePrefix); len(role) > 0 {
+				roles.Insert(role)
+			}
+		case k == nodeLabelRole && v != "":
+			roles.Insert(v)
+		}
+	}
+
+	return roles.List()
+}

--- a/components/processors/observek8sattributesprocessor/noderoles.go
+++ b/components/processors/observek8sattributesprocessor/noderoles.go
@@ -31,7 +31,7 @@ func getNodeRoles(objLog plog.LogRecord) (attributes, error) {
 	var node v1.Node
 	err := json.Unmarshal([]byte(objLog.Body().AsString()), &node)
 	if err != nil {
-		return nil, errors.New("Error while unmarshalling Node")
+		return nil, errors.New("could not unmarshal Node")
 	}
 	// based on https://github.com/kubernetes/kubernetes/blob/dbc2b0a5c7acc349ea71a14e49913661eaf708d2/pkg/printers/internalversion/printers.go#L183https://github.com/kubernetes/kubernetes/blob/1e12d92a5179dbfeb455c79dbf9120c8536e5f9c/pkg/printers/internalversion/printers.go#L14875
 	roles := sets.NewString()

--- a/components/processors/observek8sattributesprocessor/nodestatus.go
+++ b/components/processors/observek8sattributesprocessor/nodestatus.go
@@ -1,0 +1,53 @@
+package observek8sattributesprocessor
+
+import (
+	"encoding/json"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	NodeStatusAttributeKey = "status"
+)
+
+var NodeStatusAction = K8sEventProcessorAction{
+	Key:      NodeStatusAttributeKey,
+	ValueFn:  getNodeStatus,
+	FilterFn: filterNodeEvents,
+}
+
+func filterNodeEvents(event K8sEvent) bool {
+	return event.Kind == "Node"
+}
+
+// Generates the Node "status" facet. Assumes that objLog is a log from a Node event.
+func getNodeStatus(objLog plog.LogRecord) any {
+	var n apiv1.Node
+	err := json.Unmarshal([]byte(objLog.Body().AsString()), &n)
+	if err != nil {
+		return "Error while computing status"
+	}
+	// based on https://github.com/kubernetes/kubernetes/blob/dbc2b0a5c7acc349ea71a14e49913661eaf708d2/pkg/printers/internalversion/printers.go#L1835
+	// Although with a simplified logic that is faster to compute and uses less memory
+	var status string
+	// For now, we only care about "Ready"/"Not Ready", that's why we simplify the logic
+	for _, condition := range n.Status.Conditions {
+		if condition.Type != apiv1.NodeReady {
+			continue
+		}
+		status = string(condition.Type)
+		if condition.Status == apiv1.ConditionFalse {
+			status = "Not" + status
+		}
+	}
+	// If there's no Ready condition in the status, use Unknown
+	if status == "" {
+		status = "Unknown"
+	}
+	if n.Spec.Unschedulable {
+		status += ", SchedulingDisabled"
+	}
+
+	return status
+}

--- a/components/processors/observek8sattributesprocessor/pod.go
+++ b/components/processors/observek8sattributesprocessor/pod.go
@@ -1,0 +1,5 @@
+package observek8sattributesprocessor
+
+func filterPodEvents(event K8sEvent) bool {
+	return event.Kind == "Pod"
+}

--- a/components/processors/observek8sattributesprocessor/podcounts.go
+++ b/components/processors/observek8sattributesprocessor/podcounts.go
@@ -1,0 +1,57 @@
+package observek8sattributesprocessor
+
+import (
+	"encoding/json"
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// This action will be ignored and not written in any of the facets, since
+	// we return map[string]any
+	PodContainerRestartsAttributeKey = "restarts"
+	PodTotalContainersAttributeKey   = "total_containers"
+	PodReadyContainersAttributeKey   = "ready_containers"
+)
+
+// This action computes various facets for Pod by aggregating "status" values
+// across all containers of a Pod.
+//
+// We compute more facets into a single action to avoid iterating over the
+// same slice multiple times in different actions.
+var PodContainersCountsAction = K8sEventProcessorAction{
+	ComputeAttributes: getPodCounts,
+	FilterFn:          filterPodEvents,
+}
+
+func getPodCounts(objLog plog.LogRecord) (attributes, error) {
+	var p v1.Pod
+	err := json.Unmarshal([]byte(objLog.Body().AsString()), &p)
+	if err != nil {
+		return nil, errors.New("Unknown")
+	}
+	// we use int32 since containerStatuses.restartCount is int32
+	var restartsCount int32
+	// We don't need to use a hash set on the container ID for these two facets,
+	// since the containerStatuses contain one entry per container.
+	var readyContainers int64
+	var allContainers int64
+
+	for _, stat := range p.Status.ContainerStatuses {
+		restartsCount += stat.RestartCount
+		allContainers++
+		if stat.Ready {
+			readyContainers++
+		}
+	}
+
+	// Returning map[string]any will make the processor add its elements as
+	// separate facets, rather than adding the whole map under the key of this action
+	return attributes{
+		PodContainerRestartsAttributeKey: int64(restartsCount),
+		PodTotalContainersAttributeKey:   allContainers,
+		PodReadyContainersAttributeKey:   readyContainers,
+	}, nil
+}

--- a/components/processors/observek8sattributesprocessor/podreadiness.go
+++ b/components/processors/observek8sattributesprocessor/podreadiness.go
@@ -1,0 +1,54 @@
+package observek8sattributesprocessor
+
+import (
+	"encoding/json"
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// This action will be ignored and not written in any of the facets, since
+	// we return map[string]any
+	PodReadinessGatesReadyAttributeKey = "readinessGatesReady"
+	PodReadinessGatesTotalAttributeKey = "readinessGatesTotal"
+)
+
+// This action computes various facets for Pod by aggregating "status" values
+// across all containers of a Pod.
+//
+// We compute more facets into a single action to avoid iterating over the
+// same slice multiple times in different actions.
+var PodReadinessAction = K8sEventProcessorAction{
+	ComputeAttributes: getPodReadiness,
+	FilterFn:          filterPodEvents,
+}
+
+func getPodReadiness(objLog plog.LogRecord) (attributes, error) {
+	var pod v1.Pod
+	err := json.Unmarshal([]byte(objLog.Body().AsString()), &pod)
+	if err != nil {
+		return nil, errors.New("could not unmarshal Pod")
+	}
+	readinessGatesReady := 0
+
+	if len(pod.Spec.ReadinessGates) > 0 {
+		for _, readinessGate := range pod.Spec.ReadinessGates {
+			conditionType := readinessGate.ConditionType
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == conditionType {
+					if condition.Status == v1.ConditionTrue {
+						readinessGatesReady++
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return attributes{
+		PodReadinessGatesTotalAttributeKey: len(pod.Spec.ReadinessGates),
+		PodReadinessGatesReadyAttributeKey: readinessGatesReady,
+	}, nil
+}

--- a/components/processors/observek8sattributesprocessor/podstatus.go
+++ b/components/processors/observek8sattributesprocessor/podstatus.go
@@ -20,15 +20,16 @@ type OTELKubernetesEvent struct {
 
 var PodStatusAction = K8sEventProcessorAction{
 	Key:      PodStatusAttributeKey,
-	ValueFn:  getStatus,
-	FilterFn: filterFn,
+	ValueFn:  getPodStatus,
+	FilterFn: filterPodEvents,
 }
 
-func filterFn(event K8sEvent) bool {
+func filterPodEvents(event K8sEvent) bool {
 	return event.Kind == "Pod"
 }
 
-func getStatus(objLog plog.LogRecord) string {
+// Generates the Pod "status" facet. Assumes that objLog is a log from a Pod event.
+func getPodStatus(objLog plog.LogRecord) any {
 	var p v1.Pod
 	err := json.Unmarshal([]byte(objLog.Body().AsString()), &p)
 	if err != nil {

--- a/components/processors/observek8sattributesprocessor/processor.go
+++ b/components/processors/observek8sattributesprocessor/processor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -22,7 +23,7 @@ type K8sEventsProcessor struct {
 
 type K8sEventProcessorAction struct {
 	Key      string
-	ValueFn  func(plog.LogRecord) string
+	ValueFn  func(plog.LogRecord) any
 	FilterFn func(K8sEvent) bool
 }
 
@@ -31,7 +32,7 @@ func newK8sEventsProcessor(logger *zap.Logger, cfg component.Config) *K8sEventsP
 		cfg:    cfg,
 		logger: logger,
 		actions: []K8sEventProcessorAction{
-			PodStatusAction,
+			PodStatusAction, NodeStatusAction, NodeRolesAction,
 		},
 	}
 }
@@ -55,28 +56,68 @@ func (kep *K8sEventsProcessor) processLogs(_ context.Context, logs plog.Logs) (p
 			for k := 0; k < lrs.Len(); k++ {
 				lr := lrs.At(k)
 				var event K8sEvent
-				err := json.Unmarshal([]byte(lr.Body().AsString()), &event)
+				bodyStr := lr.Body().AsString()
+				err := json.Unmarshal([]byte(bodyStr), &event)
 				if err != nil {
 					kep.logger.Error("failed to unmarshal event", zap.Error(err))
 					continue
 				}
+				var transformMap pcommon.Map
+				var facetsMap pcommon.Map
 				for _, action := range kep.actions {
 					if action.FilterFn != nil && !action.FilterFn(event) {
 						continue
 					}
 					transform, exists := lr.Attributes().Get("observe_transform")
 					if exists {
-						facets, exists := transform.Map().Get("facets")
-						if exists {
-							facets.Map().PutStr(action.Key, action.ValueFn(lr))
-						} else {
-							facets := transform.Map().PutEmptyMap("facets")
-							facets.PutStr(action.Key, action.ValueFn(lr))
-						}
+						transformMap = transform.Map()
 					} else {
-						transform := lr.Attributes().PutEmptyMap("observe_transform")
-						facets := transform.PutEmptyMap("facets")
-						facets.PutStr(action.Key, action.ValueFn(lr))
+						transformMap = lr.Attributes().PutEmptyMap("observe_transform")
+					}
+					facets, exists := transformMap.Get("facets")
+					if exists {
+						facetsMap = facets.Map()
+					} else {
+						facetsMap = transformMap.PutEmptyMap("facets")
+					}
+
+					// This is where the custom processor actually computes the value
+					value := action.ValueFn(lr)
+
+					// TODO [eg] we probably want to make this more modular. For
+					// now using FromRaw for complex types is fine, since we
+					// don't plan to generate arbitrarily complex/nested facets.
+					// For some time coming we will produce facets that are at
+					// most slices of simple types of map of simple types,
+					// nothing beyond that.
+					switch typed := value.(type) {
+					case string:
+						facetsMap.PutStr(action.Key, typed)
+					case int64:
+						facetsMap.PutInt(action.Key, typed)
+					case bool:
+						facetsMap.PutBool(action.Key, typed)
+					case float64:
+						facetsMap.PutDouble(action.Key, typed)
+					case []string:
+						// []string can't fallback to using FromRaw([]any), as
+						// the default implementation of FromRaw is not smart
+						// enough to understand that the slice contains all
+						// string, and inserts them as bytes, instead
+						slc := facetsMap.PutEmptySlice(action.Key)
+						slc.EnsureCapacity(len(typed))
+						for _, str := range typed {
+							slc.AppendEmpty().SetStr(str)
+						}
+					case map[string]string:
+						// Same reasoning as []string
+						mp := facetsMap.PutEmptyMap(action.Key)
+						mp.EnsureCapacity(len(typed))
+						for k, v := range typed {
+							mp.PutStr(k, v)
+						}
+					default:
+						kep.logger.Error("sending the generated facet to Observe in bytes since no custom serialization logic is implemented", zap.Error(err))
 					}
 				}
 			}

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -2,125 +2,153 @@ package observek8sattributesprocessor
 
 import (
 	"context"
-	"io/ioutil"
+	"encoding/json"
+	"os"
 	"testing"
 
+	"github.com/jmespath/go-jmespath"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
 
-type observeTransformFacets struct {
-	facets map[string]string
-}
+// TODO [eg] refactor the testing infrastructure
 
 type logWithResource struct {
 	logName            string
 	resourceAttributes map[string]any
-	recordAttributes   map[string]any
-	severityText       string
-	body               string
-	testBodyFilepath   string
-	severityNumber     plog.SeverityNumber
+	// These attributes simulate the enrichments performed on top of the raw
+	// event by the pipelines in the agent config (generated from the template
+	// in the helm repo)
+	recordAttributes map[string]any
+	severityText     string
+	body             string
+	testBodyFilepath string
+	severityNumber   plog.SeverityNumber
 }
 
-type K8sEventProcessorTest struct {
-	name          string
-	inLogs        plog.Logs
-	outAttributes []map[string]interface{}
+// models a jmespath query against the processed results
+type queryWithResult struct {
+	path      string
+	expResult any
 }
 
-var (
-	podStatusInLogs = []logWithResource{
-		{
-			logName:          "noObserveTransformAttributes",
-			testBodyFilepath: "./testdata/podObjectEvent.json",
-		},
-		{
-			logName:          "existingObserveTransformAttributes",
-			testBodyFilepath: "./testdata/podObjectEvent.json",
-			recordAttributes: map[string]any{
-				"observe_transform": map[string]any{
-					"facets": map[string]any{
-						"other_key": "test",
-					},
-				},
-			},
-		},
-	}
-	podStatusOutAttributes = []map[string]interface{}{
-		{
-			"observe_transform": map[string]interface{}{
-				"facets": map[string]interface{}{
-					"status": "Terminating",
-				},
-			},
-			"name": "noObserveTransformAttributes",
-		},
-		{
-			"observe_transform": map[string]interface{}{
-				"facets": map[string]interface{}{
-					"status":    "Terminating",
-					"other_key": "test",
-				},
-			},
-			"name": "existingObserveTransformAttributes",
-		},
-	}
-
-	tests = []K8sEventProcessorTest{
-		{
-			name:          "noObserveTransformAttributes",
-			inLogs:        testResourceLogs(podStatusInLogs),
-			outAttributes: podStatusOutAttributes,
-		},
-	}
-)
+type k8sEventProcessorTest struct {
+	name            string
+	inLogs          plog.Logs
+	expectedResults []queryWithResult
+}
 
 func TestK8sEventsProcessor(t *testing.T) {
-	for _, test := range tests {
+	for _, test := range []k8sEventProcessorTest{
+		{
+			name: "noObserveTransformAttributes",
+			inLogs: createResourceLogs(
+				logWithResource{
+					logName:          "noObserveTransformAttributes",
+					testBodyFilepath: "./testdata/podObjectEvent.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.status", "Terminating"},
+			},
+		},
+		{ // Tests that we don't override/drop other facets computed in OTTL
+			name: "existingObserveTransformAttributes",
+			inLogs: createResourceLogs(
+				logWithResource{
+					logName:          "existingObserveTransformAttributes",
+					testBodyFilepath: "./testdata/podObjectEvent.json",
+					recordAttributes: map[string]any{
+						"observe_transform": map[string]interface{}{
+							"facets": map[string]interface{}{
+								"other_key": "test",
+							},
+						},
+						"name": "existingObserveTransformAttributes",
+					},
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.status", "Terminating"},
+				{"observe_transform.facets.other_key", "test"},
+			},
+		},
+		{
+			name: "Node Status and Role",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/nodeObjectEventSimple.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.status", "Ready"},
+				{"observe_transform.facets.roles | length(@)", float64(1)},
+				{"observe_transform.facets.roles[0]", "control-plane"},
+			},
+		},
+		{
+			name: "Node Status and Multiple Roles",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/nodeObjectEventAlternativeRoleKey.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.status", "Ready"},
+				{"observe_transform.facets.roles | length(@)", float64(2)},
+				{"observe_transform.facets.roles", []any{"anotherRole!", "control-plane"}},
+			},
+		},
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			kep := newK8sEventsProcessor(zap.NewNop(), &Config{})
 			logs, err := kep.processLogs(context.Background(), test.inLogs)
-			for i := 0; i < logs.ResourceLogs().Len(); i++ {
-				sl := logs.ResourceLogs().At(i).ScopeLogs()
-				for j := 0; j < sl.Len(); j++ {
-					lr := sl.At(j).LogRecords()
-					require.Equal(t, test.outAttributes[i], lr.At(0).Attributes().AsRaw())
-				}
-			}
-
 			require.NoError(t, err)
+			// Since we don't do correlation among different logs, each testcase
+			// "Logs" contains only one ResourceLog with one ScopeLog and a single LogRecord
+			out := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()
+			for _, query := range test.expectedResults {
+				queryJmes, err := jmespath.Compile(query.path)
+				require.NoErrorf(t, err, "path %v is not a valid jmespath", query.path)
+				res, err := queryJmes.Search(out)
+				require.NoError(t, err, "error in extracting jmespath")
+				require.Equal(t, query.expResult, res, "Processed log doesn't match the expected query")
+			}
 		})
 	}
 }
 
-func testResourceLogs(lwrs []logWithResource) plog.Logs {
+// Creates Logs with a single log.
+func createResourceLogs(lwr logWithResource) plog.Logs {
 	ld := plog.NewLogs()
 
-	for i, lwr := range lwrs {
-		rl := ld.ResourceLogs().AppendEmpty()
+	rl := ld.ResourceLogs().AppendEmpty()
 
-		// Add resource level attributes
-		//nolint:errcheck
-		rl.Resource().Attributes().FromRaw(lwr.resourceAttributes)
-		ls := rl.ScopeLogs().AppendEmpty().LogRecords()
-		l := ls.AppendEmpty()
-		// Add record level attributes
-		//nolint:errcheck
-		l.Attributes().FromRaw(lwrs[i].recordAttributes)
-		l.Attributes().PutStr("name", lwr.logName)
-		// Set body & severity fields
-		if lwr.body != "" {
-			l.Body().SetStr(lwr.body)
-		} else if lwr.testBodyFilepath != "" {
-			file, err := ioutil.ReadFile(lwr.testBodyFilepath)
-			if err == nil {
-				l.Body().SetStr(string(file))
-			}
+	// Add resource level attributes
+	//nolint:errcheck
+	rl.Resource().Attributes().FromRaw(lwr.resourceAttributes)
+	ls := rl.ScopeLogs().AppendEmpty().LogRecords()
+	l := ls.AppendEmpty()
+	// Add record level attributes
+	//nolint:errcheck
+	l.Attributes().FromRaw(lwr.recordAttributes)
+	l.Attributes().PutStr("name", lwr.logName)
+	// Set body & severity fields
+	if lwr.body != "" {
+		// Check that the body is a valid json
+		_, err := json.Marshal(lwr.body)
+		if err != nil {
+			panic(err)
 		}
-		l.SetSeverityText(lwr.severityText)
-		l.SetSeverityNumber(lwr.severityNumber)
+		l.Body().SetStr(lwr.body)
+	} else if lwr.testBodyFilepath != "" {
+		file, err := os.ReadFile(lwr.testBodyFilepath)
+		if err == nil {
+			l.Body().SetStr(string(file))
+		}
 	}
+	l.SetSeverityText(lwr.severityText)
+	l.SetSeverityNumber(lwr.severityNumber)
 	return ld
 }

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -111,6 +111,18 @@ func TestK8sEventsProcessor(t *testing.T) {
 				{"observe_transform.facets.ready_containers", int64(3)},
 			},
 		},
+		{
+			name: "Pod readiness gates",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/podObjectEventWithReadinessGates.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.readinessGatesReady", int64(1)},
+				{"observe_transform.facets.readinessGatesTotal", int64(2)},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			kep := newK8sEventsProcessor(zap.NewNop(), &Config{})

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -45,7 +45,6 @@ func TestK8sEventsProcessor(t *testing.T) {
 			name: "noObserveTransformAttributes",
 			inLogs: createResourceLogs(
 				logWithResource{
-					logName:          "noObserveTransformAttributes",
 					testBodyFilepath: "./testdata/podObjectEvent.json",
 				},
 			),
@@ -57,7 +56,6 @@ func TestK8sEventsProcessor(t *testing.T) {
 			name: "existingObserveTransformAttributes",
 			inLogs: createResourceLogs(
 				logWithResource{
-					logName:          "existingObserveTransformAttributes",
 					testBodyFilepath: "./testdata/podObjectEvent.json",
 					recordAttributes: map[string]any{
 						"observe_transform": map[string]interface{}{
@@ -98,6 +96,19 @@ func TestK8sEventsProcessor(t *testing.T) {
 				{"observe_transform.facets.status", "Ready"},
 				{"observe_transform.facets.roles | length(@)", float64(2)},
 				{"observe_transform.facets.roles", []any{"anotherRole!", "control-plane"}},
+			},
+		},
+		{
+			name: "Pod container counts",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/podObjectEvent.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.restarts", int64(5)},
+				{"observe_transform.facets.total_containers", int64(4)},
+				{"observe_transform.facets.ready_containers", int64(3)},
 			},
 		},
 	} {

--- a/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventAlternativeRoleKey.json
+++ b/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventAlternativeRoleKey.json
@@ -1,0 +1,265 @@
+{
+    "apiVersion": "v1",
+    "kind": "Node",
+    "metadata": {
+        "annotations": {
+            "kubeadm.alpha.kubernetes.io/cri-socket": "unix:///var/run/cri-dockerd.sock",
+            "node.alpha.kubernetes.io/ttl": "0",
+            "projectcalico.org/IPv4Address": "192.168.49.2/24",
+            "projectcalico.org/IPv4IPIPTunnelAddr": "10.244.120.66",
+            "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        },
+        "creationTimestamp": "2024-08-13T14:46:59Z",
+        "labels": {
+            "beta.kubernetes.io/arch": "arm64",
+            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/arch": "arm64",
+            "kubernetes.io/hostname": "minikube",
+            "kubernetes.io/os": "linux",
+            "minikube.k8s.io/commit": "5883c09216182566a63dff4c326a6fc9ed2982ff",
+            "minikube.k8s.io/name": "minikube",
+            "minikube.k8s.io/primary": "true",
+            "minikube.k8s.io/updated_at": "2024_08_13T16_47_02_0700",
+            "minikube.k8s.io/version": "v1.33.1",
+            "node-role.kubernetes.io/control-plane": "",
+            "kubernetes.io/role": "anotherRole!",
+            "node.kubernetes.io/exclude-from-external-load-balancers": ""
+        },
+        "name": "minikube",
+        "resourceVersion": "78297",
+        "uid": "70cc7335-4945-4b76-8734-604a9d095d82"
+    },
+    "spec": {
+        "podCIDR": "10.244.0.0/24",
+        "podCIDRs": [
+            "10.244.0.0/24"
+        ]
+    },
+    "status": {
+        "addresses": [
+            {
+                "address": "192.168.49.2",
+                "type": "InternalIP"
+            },
+            {
+                "address": "minikube",
+                "type": "Hostname"
+            }
+        ],
+        "allocatable": {
+            "cpu": "12",
+            "ephemeral-storage": "61202244Ki",
+            "hugepages-1Gi": "0",
+            "hugepages-2Mi": "0",
+            "hugepages-32Mi": "0",
+            "hugepages-64Ki": "0",
+            "memory": "8028668Ki",
+            "pods": "110"
+        },
+        "capacity": {
+            "cpu": "12",
+            "ephemeral-storage": "61202244Ki",
+            "hugepages-1Gi": "0",
+            "hugepages-2Mi": "0",
+            "hugepages-32Mi": "0",
+            "hugepages-64Ki": "0",
+            "memory": "8028668Ki",
+            "pods": "110"
+        },
+        "conditions": [
+            {
+                "lastHeartbeatTime": "2024-08-14T13:59:19Z",
+                "lastTransitionTime": "2024-08-14T13:59:19Z",
+                "message": "Calico is running on this node",
+                "reason": "CalicoIsUp",
+                "status": "False",
+                "type": "NetworkUnavailable"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has sufficient memory available",
+                "reason": "KubeletHasSufficientMemory",
+                "status": "False",
+                "type": "MemoryPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has no disk pressure",
+                "reason": "KubeletHasNoDiskPressure",
+                "status": "False",
+                "type": "DiskPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has sufficient PID available",
+                "reason": "KubeletHasSufficientPID",
+                "status": "False",
+                "type": "PIDPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:59Z",
+                "message": "kubelet is posting ready status",
+                "reason": "KubeletReady",
+                "status": "True",
+                "type": "Ready"
+            }
+        ],
+        "daemonEndpoints": {
+            "kubeletEndpoint": {
+                "Port": 10250
+            }
+        },
+        "images": [
+            {
+                "names": [
+                    "calico/node@sha256:78dadbe45a1a76f685d5fa777fdec807a86368b8e748cb27dad14723e233803c",
+                    "calico/node:v3.27.3"
+                ],
+                "sizeBytes": 512037489
+            },
+            {
+                "names": [
+                    "otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+                    "otel/opentelemetry-collector-contrib:0.104.0"
+                ],
+                "sizeBytes": 246441510
+            },
+            {
+                "names": null,
+                "sizeBytes": 194754621
+            },
+            {
+                "names": null,
+                "sizeBytes": 194750959
+            },
+            {
+                "names": [
+                    "observe-agent:test-k8s"
+                ],
+                "sizeBytes": 194750844
+            },
+            {
+                "names": null,
+                "sizeBytes": 194750087
+            },
+            {
+                "names": null,
+                "sizeBytes": 194749028
+            },
+            {
+                "names": null,
+                "sizeBytes": 194747136
+            },
+            {
+                "names": null,
+                "sizeBytes": 194746632
+            },
+            {
+                "names": [
+                    "observe-agent2:test-k8s-v2"
+                ],
+                "sizeBytes": 193958968
+            },
+            {
+                "names": [
+                    "calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f",
+                    "calico/cni:v3.27.3"
+                ],
+                "sizeBytes": 186805827
+            },
+            {
+                "names": [
+                    "observeinc/observe-agent@sha256:f00b5d68d1cdaa5861175d73c90c15b20fa79b27578f1cda42f8b0351c232378",
+                    "observeinc/observe-agent:0.9.0"
+                ],
+                "sizeBytes": 141536696
+            },
+            {
+                "names": [
+                    "registry.k8s.io/etcd@sha256:44a8e24dcbba3470ee1fee21d5e88d128c936e9b55d4bc51fbef8086f8ed123b",
+                    "registry.k8s.io/etcd:3.5.12-0"
+                ],
+                "sizeBytes": 138984067
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-apiserver@sha256:6b8e197b2d39c321189a475ac755a77896e34b56729425590fbc99f3a96468a3",
+                    "registry.k8s.io/kube-apiserver:v1.30.0"
+                ],
+                "sizeBytes": 112480900
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-controller-manager@sha256:5f52f00f17d5784b5ca004dffca59710fa1a9eec8d54cebdf9433a1d134150fe",
+                    "registry.k8s.io/kube-controller-manager:v1.30.0"
+                ],
+                "sizeBytes": 107172834
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-proxy@sha256:ec532ff47eaf39822387e51ec73f1f2502eb74658c6303319db88d2c380d0210",
+                    "registry.k8s.io/kube-proxy:v1.30.0"
+                ],
+                "sizeBytes": 87874752
+            },
+            {
+                "names": [
+                    "calico/kube-controllers@sha256:3e8bc2000187cc71346538aaa8e10cd7941ba75f744e315f48b3a3293399a495",
+                    "calico/kube-controllers:v3.27.3"
+                ],
+                "sizeBytes": 70261593
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-scheduler@sha256:2353c3a1803229970fcb571cffc9b2f120372350e01c7381b4b650c4a02b9d67",
+                    "registry.k8s.io/kube-scheduler:v1.30.0"
+                ],
+                "sizeBytes": 60511189
+            },
+            {
+                "names": [
+                    "registry.k8s.io/coredns/coredns@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1",
+                    "registry.k8s.io/coredns/coredns:v1.11.1"
+                ],
+                "sizeBytes": 57387595
+            },
+            {
+                "names": [
+                    "gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944",
+                    "gcr.io/k8s-minikube/storage-provisioner:v5"
+                ],
+                "sizeBytes": 29032448
+            },
+            {
+                "names": [
+                    "observeinc/kube-cluster-info@sha256:c574e14860df6af618677311eaa8dba6700c4ca0a04ddca52d3a1bf2b9c4fc85",
+                    "observeinc/kube-cluster-info:v0.11.1"
+                ],
+                "sizeBytes": 19308076
+            },
+            {
+                "names": [
+                    "registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097",
+                    "registry.k8s.io/pause:3.9"
+                ],
+                "sizeBytes": 514000
+            }
+        ],
+        "nodeInfo": {
+            "architecture": "arm64",
+            "bootID": "2bbbb29f-9450-4a6d-bda5-71b33c60b5d9",
+            "containerRuntimeVersion": "docker://26.1.1",
+            "kernelVersion": "6.6.32-linuxkit",
+            "kubeProxyVersion": "v1.30.0",
+            "kubeletVersion": "v1.30.0",
+            "machineID": "4db5e5177c6e48f1ab31ebf19eea7232",
+            "operatingSystem": "linux",
+            "osImage": "Ubuntu 22.04.4 LTS",
+            "systemUUID": "4db5e5177c6e48f1ab31ebf19eea7232"
+        }
+    }
+}

--- a/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventSimple.json
+++ b/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventSimple.json
@@ -1,0 +1,264 @@
+{
+    "apiVersion": "v1",
+    "kind": "Node",
+    "metadata": {
+        "annotations": {
+            "kubeadm.alpha.kubernetes.io/cri-socket": "unix:///var/run/cri-dockerd.sock",
+            "node.alpha.kubernetes.io/ttl": "0",
+            "projectcalico.org/IPv4Address": "192.168.49.2/24",
+            "projectcalico.org/IPv4IPIPTunnelAddr": "10.244.120.66",
+            "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        },
+        "creationTimestamp": "2024-08-13T14:46:59Z",
+        "labels": {
+            "beta.kubernetes.io/arch": "arm64",
+            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/arch": "arm64",
+            "kubernetes.io/hostname": "minikube",
+            "kubernetes.io/os": "linux",
+            "minikube.k8s.io/commit": "5883c09216182566a63dff4c326a6fc9ed2982ff",
+            "minikube.k8s.io/name": "minikube",
+            "minikube.k8s.io/primary": "true",
+            "minikube.k8s.io/updated_at": "2024_08_13T16_47_02_0700",
+            "minikube.k8s.io/version": "v1.33.1",
+            "node-role.kubernetes.io/control-plane": "",
+            "node.kubernetes.io/exclude-from-external-load-balancers": ""
+        },
+        "name": "minikube",
+        "resourceVersion": "78297",
+        "uid": "70cc7335-4945-4b76-8734-604a9d095d82"
+    },
+    "spec": {
+        "podCIDR": "10.244.0.0/24",
+        "podCIDRs": [
+            "10.244.0.0/24"
+        ]
+    },
+    "status": {
+        "addresses": [
+            {
+                "address": "192.168.49.2",
+                "type": "InternalIP"
+            },
+            {
+                "address": "minikube",
+                "type": "Hostname"
+            }
+        ],
+        "allocatable": {
+            "cpu": "12",
+            "ephemeral-storage": "61202244Ki",
+            "hugepages-1Gi": "0",
+            "hugepages-2Mi": "0",
+            "hugepages-32Mi": "0",
+            "hugepages-64Ki": "0",
+            "memory": "8028668Ki",
+            "pods": "110"
+        },
+        "capacity": {
+            "cpu": "12",
+            "ephemeral-storage": "61202244Ki",
+            "hugepages-1Gi": "0",
+            "hugepages-2Mi": "0",
+            "hugepages-32Mi": "0",
+            "hugepages-64Ki": "0",
+            "memory": "8028668Ki",
+            "pods": "110"
+        },
+        "conditions": [
+            {
+                "lastHeartbeatTime": "2024-08-14T13:59:19Z",
+                "lastTransitionTime": "2024-08-14T13:59:19Z",
+                "message": "Calico is running on this node",
+                "reason": "CalicoIsUp",
+                "status": "False",
+                "type": "NetworkUnavailable"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has sufficient memory available",
+                "reason": "KubeletHasSufficientMemory",
+                "status": "False",
+                "type": "MemoryPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has no disk pressure",
+                "reason": "KubeletHasNoDiskPressure",
+                "status": "False",
+                "type": "DiskPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:58Z",
+                "message": "kubelet has sufficient PID available",
+                "reason": "KubeletHasSufficientPID",
+                "status": "False",
+                "type": "PIDPressure"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-14T15:36:42Z",
+                "lastTransitionTime": "2024-08-13T14:46:59Z",
+                "message": "kubelet is posting ready status",
+                "reason": "KubeletReady",
+                "status": "True",
+                "type": "Ready"
+            }
+        ],
+        "daemonEndpoints": {
+            "kubeletEndpoint": {
+                "Port": 10250
+            }
+        },
+        "images": [
+            {
+                "names": [
+                    "calico/node@sha256:78dadbe45a1a76f685d5fa777fdec807a86368b8e748cb27dad14723e233803c",
+                    "calico/node:v3.27.3"
+                ],
+                "sizeBytes": 512037489
+            },
+            {
+                "names": [
+                    "otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+                    "otel/opentelemetry-collector-contrib:0.104.0"
+                ],
+                "sizeBytes": 246441510
+            },
+            {
+                "names": null,
+                "sizeBytes": 194754621
+            },
+            {
+                "names": null,
+                "sizeBytes": 194750959
+            },
+            {
+                "names": [
+                    "observe-agent:test-k8s"
+                ],
+                "sizeBytes": 194750844
+            },
+            {
+                "names": null,
+                "sizeBytes": 194750087
+            },
+            {
+                "names": null,
+                "sizeBytes": 194749028
+            },
+            {
+                "names": null,
+                "sizeBytes": 194747136
+            },
+            {
+                "names": null,
+                "sizeBytes": 194746632
+            },
+            {
+                "names": [
+                    "observe-agent2:test-k8s-v2"
+                ],
+                "sizeBytes": 193958968
+            },
+            {
+                "names": [
+                    "calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f",
+                    "calico/cni:v3.27.3"
+                ],
+                "sizeBytes": 186805827
+            },
+            {
+                "names": [
+                    "observeinc/observe-agent@sha256:f00b5d68d1cdaa5861175d73c90c15b20fa79b27578f1cda42f8b0351c232378",
+                    "observeinc/observe-agent:0.9.0"
+                ],
+                "sizeBytes": 141536696
+            },
+            {
+                "names": [
+                    "registry.k8s.io/etcd@sha256:44a8e24dcbba3470ee1fee21d5e88d128c936e9b55d4bc51fbef8086f8ed123b",
+                    "registry.k8s.io/etcd:3.5.12-0"
+                ],
+                "sizeBytes": 138984067
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-apiserver@sha256:6b8e197b2d39c321189a475ac755a77896e34b56729425590fbc99f3a96468a3",
+                    "registry.k8s.io/kube-apiserver:v1.30.0"
+                ],
+                "sizeBytes": 112480900
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-controller-manager@sha256:5f52f00f17d5784b5ca004dffca59710fa1a9eec8d54cebdf9433a1d134150fe",
+                    "registry.k8s.io/kube-controller-manager:v1.30.0"
+                ],
+                "sizeBytes": 107172834
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-proxy@sha256:ec532ff47eaf39822387e51ec73f1f2502eb74658c6303319db88d2c380d0210",
+                    "registry.k8s.io/kube-proxy:v1.30.0"
+                ],
+                "sizeBytes": 87874752
+            },
+            {
+                "names": [
+                    "calico/kube-controllers@sha256:3e8bc2000187cc71346538aaa8e10cd7941ba75f744e315f48b3a3293399a495",
+                    "calico/kube-controllers:v3.27.3"
+                ],
+                "sizeBytes": 70261593
+            },
+            {
+                "names": [
+                    "registry.k8s.io/kube-scheduler@sha256:2353c3a1803229970fcb571cffc9b2f120372350e01c7381b4b650c4a02b9d67",
+                    "registry.k8s.io/kube-scheduler:v1.30.0"
+                ],
+                "sizeBytes": 60511189
+            },
+            {
+                "names": [
+                    "registry.k8s.io/coredns/coredns@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1",
+                    "registry.k8s.io/coredns/coredns:v1.11.1"
+                ],
+                "sizeBytes": 57387595
+            },
+            {
+                "names": [
+                    "gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944",
+                    "gcr.io/k8s-minikube/storage-provisioner:v5"
+                ],
+                "sizeBytes": 29032448
+            },
+            {
+                "names": [
+                    "observeinc/kube-cluster-info@sha256:c574e14860df6af618677311eaa8dba6700c4ca0a04ddca52d3a1bf2b9c4fc85",
+                    "observeinc/kube-cluster-info:v0.11.1"
+                ],
+                "sizeBytes": 19308076
+            },
+            {
+                "names": [
+                    "registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097",
+                    "registry.k8s.io/pause:3.9"
+                ],
+                "sizeBytes": 514000
+            }
+        ],
+        "nodeInfo": {
+            "architecture": "arm64",
+            "bootID": "2bbbb29f-9450-4a6d-bda5-71b33c60b5d9",
+            "containerRuntimeVersion": "docker://26.1.1",
+            "kernelVersion": "6.6.32-linuxkit",
+            "kubeProxyVersion": "v1.30.0",
+            "kubeletVersion": "v1.30.0",
+            "machineID": "4db5e5177c6e48f1ab31ebf19eea7232",
+            "operatingSystem": "linux",
+            "osImage": "Ubuntu 22.04.4 LTS",
+            "systemUUID": "4db5e5177c6e48f1ab31ebf19eea7232"
+        }
+    }
+}

--- a/components/processors/observek8sattributesprocessor/testdata/podObjectEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/podObjectEvent.json
@@ -513,24 +513,95 @@
       ],
       "containerStatuses":[
          {
-            "containerID":"containerd://022d7cedb7b98f84a6048375eaed1eb071c2ffb93f63353c6b3874f93c10f283",
-            "image":"723346149663.dkr.ecr.us-west-2.amazonaws.com/o2-dumper:latest",
-            "imageID":"723346149663.dkr.ecr.us-west-2.amazonaws.com/o2-dumper@sha256:25c5d2df91013ba70e10a986eab716662fc4437dd9a23051614c2d47105a2739",
-            "lastState":{
-               
+            "containerID": "docker://27e5a33803d1bf972d76ff701cf64169811167d5be9d4672ba265201b4811715",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                  "terminated": {
+                     "containerID": "docker://85c5a15d9c592ab65a74cc22c5ced1d5dd60d9d0a55390c045a93fad057a8099",
+                     "exitCode": 2,
+                     "finishedAt": "2024-08-15T03:40:38Z",
+                     "reason": "Error",
+                     "startedAt": "2024-08-14T14:00:37Z"
+                  }
             },
-            "name":"purge-old-datasets",
-            "ready":false,
-            "restartCount":0,
-            "started":false,
-            "state":{
-               "terminated":{
-                  "containerID":"containerd://022d7cedb7b98f84a6048375eaed1eb071c2ffb93f63353c6b3874f93c10f283",
-                  "exitCode":0,
-                  "finishedAt":"2024-07-18T18:53:11Z",
-                  "reason":"Completed",
-                  "startedAt":"2024-07-18T18:53:00Z"
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 1,
+            "started": true,
+            "state": {
+                  "running": {
+                     "startedAt": "2024-08-15T03:40:38Z"
+                  }
+            }
+         },
+         {
+            "containerID": "docker://6521895498486496",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+               "terminated": {
+                  "containerID": "docker://6521895498486496",
+                  "exitCode": 2,
+                  "finishedAt": "2024-08-15T03:40:38Z",
+                  "reason": "Error",
+                  "startedAt": "2024-08-14T14:00:37Z"
                }
+            },
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 1,
+            "started": true,
+            "state": {
+               "running": {
+                  "startedAt": "2024-08-15T03:40:38Z"
+               }
+            }
+         },
+         {
+            "containerID": "docker://6884237457842122313290",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                "terminated": {
+                    "containerID": "docker://6884237457842122313290",
+                    "exitCode": 2,
+                    "finishedAt": "2024-08-15T03:40:38Z",
+                    "reason": "Error",
+                    "startedAt": "2024-08-14T14:00:37Z"
+                }
+            },
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 3,
+            "started": true,
+            "state": {
+                "running": {
+                    "startedAt": "2024-08-15T03:40:38Z"
+                }
+            }
+         },
+         {
+            "containerID": "docker://6547986743222555",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                "terminated": {
+                    "containerID": "docker://6547986743222555",
+                    "exitCode": 2,
+                    "finishedAt": "2024-08-15T03:40:38Z",
+                    "reason": "Error",
+                    "startedAt": "2024-08-14T14:00:37Z"
+                }
+            },
+            "name": "deployment-cluster-events",
+            "ready": false,
+            "restartCount": 0,
+            "started": true,
+            "state": {
+                "running": {
+                    "startedAt": "2024-08-15T03:40:38Z"
+                }
             }
          }
       ],

--- a/components/processors/observek8sattributesprocessor/testdata/podObjectEventWithReadinessGates.json
+++ b/components/processors/observek8sattributesprocessor/testdata/podObjectEventWithReadinessGates.json
@@ -1,0 +1,656 @@
+{
+   "apiVersion":"v1",
+   "kind":"Pod",
+   "metadata":{
+      "annotations":{
+         "observeinc.com/kubectl-nonce":"1"
+      },
+      "creationTimestamp":"2024-07-18T18:53:00Z",
+      "deletionGracePeriodSeconds":0,
+      "deletionTimestamp":"2024-07-18T19:08:14Z",
+      "generateName":"purge-old-datasets-28688813-",
+      "labels":{
+         "batch.kubernetes.io/controller-uid":"72f87010-2ce0-422d-ae00-623ffa29e7c8",
+         "batch.kubernetes.io/job-name":"purge-old-datasets-28688813",
+         "controller-uid":"72f87010-2ce0-422d-ae00-623ffa29e7c8",
+         "job-name":"purge-old-datasets-28688813",
+         "observeinc.com/app":"apiserver",
+         "observeinc.com/environment":"eng"
+      },
+      "managedFields":[
+         {
+            "apiVersion":"v1",
+            "fieldsType":"FieldsV1",
+            "fieldsV1":{
+               "f:metadata":{
+                  "f:annotations":{
+                     ".":{
+                        
+                     },
+                     "f:observeinc.com/kubectl-nonce":{
+                        
+                     }
+                  },
+                  "f:generateName":{
+                     
+                  },
+                  "f:labels":{
+                     ".":{
+                        
+                     },
+                     "f:batch.kubernetes.io/controller-uid":{
+                        
+                     },
+                     "f:batch.kubernetes.io/job-name":{
+                        
+                     },
+                     "f:controller-uid":{
+                        
+                     },
+                     "f:job-name":{
+                        
+                     },
+                     "f:observeinc.com/app":{
+                        
+                     },
+                     "f:observeinc.com/environment":{
+                        
+                     }
+                  },
+                  "f:ownerReferences":{
+                     ".":{
+                        
+                     },
+                     "k:{\"uid\":\"72f87010-2ce0-422d-ae00-623ffa29e7c8\"}":{
+                        
+                     }
+                  }
+               },
+               "f:spec":{
+                  "f:containers":{
+                     "k:{\"name\":\"purge-old-datasets\"}":{
+                        ".":{
+                           
+                        },
+                        "f:args":{
+                           
+                        },
+                        "f:command":{
+                           
+                        },
+                        "f:env":{
+                           ".":{
+                              
+                           },
+                           "k:{\"name\":\"LIMIT\"}":{
+                              ".":{
+                                 
+                              },
+                              "f:name":{
+                                 
+                              },
+                              "f:value":{
+                                 
+                              }
+                           },
+                           "k:{\"name\":\"POSTGRES\"}":{
+                              ".":{
+                                 
+                              },
+                              "f:name":{
+                                 
+                              },
+                              "f:valueFrom":{
+                                 ".":{
+                                    
+                                 },
+                                 "f:secretKeyRef":{
+                                    
+                                 }
+                              }
+                           }
+                        },
+                        "f:envFrom":{
+                           
+                        },
+                        "f:image":{
+                           
+                        },
+                        "f:imagePullPolicy":{
+                           
+                        },
+                        "f:name":{
+                           
+                        },
+                        "f:resources":{
+                           
+                        },
+                        "f:terminationMessagePath":{
+                           
+                        },
+                        "f:terminationMessagePolicy":{
+                           
+                        },
+                        "f:volumeMounts":{
+                           ".":{
+                              
+                           },
+                           "k:{\"mountPath\":\"/configmap\"}":{
+                              ".":{
+                                 
+                              },
+                              "f:mountPath":{
+                                 
+                              },
+                              "f:name":{
+                                 
+                              },
+                              "f:readOnly":{
+                                 
+                              }
+                           }
+                        }
+                     }
+                  },
+                  "f:dnsPolicy":{
+                     
+                  },
+                  "f:enableServiceLinks":{
+                     
+                  },
+                  "f:restartPolicy":{
+                     
+                  },
+                  "f:schedulerName":{
+                     
+                  },
+                  "f:securityContext":{
+                     
+                  },
+                  "f:terminationGracePeriodSeconds":{
+                     
+                  },
+                  "f:volumes":{
+                     ".":{
+                        
+                     },
+                     "k:{\"name\":\"configmap\"}":{
+                        ".":{
+                           
+                        },
+                        "f:configMap":{
+                           ".":{
+                              
+                           },
+                           "f:defaultMode":{
+                              
+                           },
+                           "f:name":{
+                              
+                           }
+                        },
+                        "f:name":{
+                           
+                        }
+                     }
+                  }
+               }
+            },
+            "manager":"kube-controller-manager",
+            "operation":"Update",
+            "time":"2024-07-18T18:53:00Z"
+         },
+         {
+            "apiVersion":"v1",
+            "fieldsType":"FieldsV1",
+            "fieldsV1":{
+               "f:status":{
+                  "f:conditions":{
+                     "k:{\"type\":\"ContainersReady\"}":{
+                        ".":{
+                           
+                        },
+                        "f:lastProbeTime":{
+                           
+                        },
+                        "f:lastTransitionTime":{
+                           
+                        },
+                        "f:reason":{
+                           
+                        },
+                        "f:status":{
+                           
+                        },
+                        "f:type":{
+                           
+                        }
+                     },
+                     "k:{\"type\":\"Initialized\"}":{
+                        ".":{
+                           
+                        },
+                        "f:lastProbeTime":{
+                           
+                        },
+                        "f:lastTransitionTime":{
+                           
+                        },
+                        "f:reason":{
+                           
+                        },
+                        "f:status":{
+                           
+                        },
+                        "f:type":{
+                           
+                        }
+                     },
+                     "k:{\"type\":\"PodReadyToStartContainers\"}":{
+                        ".":{
+                           
+                        },
+                        "f:lastProbeTime":{
+                           
+                        },
+                        "f:lastTransitionTime":{
+                           
+                        },
+                        "f:status":{
+                           
+                        },
+                        "f:type":{
+                           
+                        }
+                     },
+                     "k:{\"type\":\"Ready\"}":{
+                        ".":{
+                           
+                        },
+                        "f:lastProbeTime":{
+                           
+                        },
+                        "f:lastTransitionTime":{
+                           
+                        },
+                        "f:reason":{
+                           
+                        },
+                        "f:status":{
+                           
+                        },
+                        "f:type":{
+                           
+                        }
+                     }
+                  },
+                  "f:containerStatuses":{
+                     
+                  },
+                  "f:hostIP":{
+                     
+                  },
+                  "f:hostIPs":{
+                     
+                  },
+                  "f:phase":{
+                     
+                  },
+                  "f:podIP":{
+                     
+                  },
+                  "f:podIPs":{
+                     ".":{
+                        
+                     },
+                     "k:{\"ip\":\"172.20.141.129\"}":{
+                        ".":{
+                           
+                        },
+                        "f:ip":{
+                           
+                        }
+                     }
+                  },
+                  "f:startTime":{
+                     
+                  }
+               }
+            },
+            "manager":"kubelet",
+            "operation":"Update",
+            "subresource":"status",
+            "time":"2024-07-18T18:53:13Z"
+         }
+      ],
+      "name":"purge-old-datasets-28688813-sspnn",
+      "namespace":"eng",
+      "ownerReferences":[
+         {
+            "apiVersion":"batch/v1",
+            "blockOwnerDeletion":true,
+            "controller":true,
+            "kind":"Job",
+            "name":"purge-old-datasets-28688813",
+            "uid":"72f87010-2ce0-422d-ae00-623ffa29e7c8"
+         }
+      ],
+      "resourceVersion":"42326591",
+      "uid":"e06298c7-c46f-4389-9fa2-c0bd57031b9c"
+   },
+   "spec":{
+      "readinessGates":[
+         {
+            "conditionType": "existingReadinessGateCondition"
+         },
+         {
+            "conditionType": "anotherConditionTypeJustForTheSakeOfIt"
+         }
+      ],
+      "containers":[
+         {
+            "args":[
+               "-c",
+               "bash /configmap/purge-old-datasets.sh\nsleep 10 # pick up logs before they go away"
+            ],
+            "command":[
+               "/bin/bash"
+            ],
+            "env":[
+               {
+                  "name":"POSTGRES",
+                  "valueFrom":{
+                     "secretKeyRef":{
+                        "key":"postgres-url",
+                        "name":"postgres-credentials"
+                     }
+                  }
+               },
+               {
+                  "name":"LIMIT",
+                  "value":"150"
+               }
+            ],
+            "envFrom":[
+               {
+                  "configMapRef":{
+                     "name":"shared-customer-env",
+                     "optional":true
+                  }
+               },
+               {
+                  "configMapRef":{
+                     "name":"apiserver-env-755mb8k94k",
+                     "optional":true
+                  }
+               }
+            ],
+            "image":"723346149663.dkr.ecr.us-west-2.amazonaws.com/o2-dumper",
+            "imagePullPolicy":"Always",
+            "name":"purge-old-datasets",
+            "resources":{
+               
+            },
+            "terminationMessagePath":"/dev/termination-log",
+            "terminationMessagePolicy":"File",
+            "volumeMounts":[
+               {
+                  "mountPath":"/configmap",
+                  "name":"configmap",
+                  "readOnly":true
+               },
+               {
+                  "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name":"kube-api-access-66vlv",
+                  "readOnly":true
+               }
+            ]
+         }
+      ],
+      "dnsPolicy":"ClusterFirst",
+      "enableServiceLinks":true,
+      "nodeName":"ip-172-20-150-131.us-west-2.compute.internal",
+      "preemptionPolicy":"PreemptLowerPriority",
+      "priority":10000,
+      "priorityClassName":"observe-normal",
+      "restartPolicy":"Never",
+      "schedulerName":"default-scheduler",
+      "securityContext":{
+         
+      },
+      "serviceAccount":"default",
+      "serviceAccountName":"default",
+      "terminationGracePeriodSeconds":30,
+      "tolerations":[
+         {
+            "effect":"NoExecute",
+            "key":"node.kubernetes.io/not-ready",
+            "operator":"Exists",
+            "tolerationSeconds":300
+         },
+         {
+            "effect":"NoExecute",
+            "key":"node.kubernetes.io/unreachable",
+            "operator":"Exists",
+            "tolerationSeconds":300
+         }
+      ],
+      "volumes":[
+         {
+            "configMap":{
+               "defaultMode":420,
+               "name":"purge-old-datasets-52khkmft45"
+            },
+            "name":"configmap"
+         },
+         {
+            "name":"kube-api-access-66vlv",
+            "projected":{
+               "defaultMode":420,
+               "sources":[
+                  {
+                     "serviceAccountToken":{
+                        "expirationSeconds":3607,
+                        "path":"token"
+                     }
+                  },
+                  {
+                     "configMap":{
+                        "items":[
+                           {
+                              "key":"ca.crt",
+                              "path":"ca.crt"
+                           }
+                        ],
+                        "name":"kube-root-ca.crt"
+                     }
+                  },
+                  {
+                     "downwardAPI":{
+                        "items":[
+                           {
+                              "fieldRef":{
+                                 "apiVersion":"v1",
+                                 "fieldPath":"metadata.namespace"
+                              },
+                              "path":"namespace"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   },
+   "status":{
+      "conditions":[
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:12Z",
+            "status":"False",
+            "type":"PodReadyToStartContainers"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "reason":"PodCompleted",
+            "status":"True",
+            "type":"Initialized"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:11Z",
+            "reason":"PodCompleted",
+            "status":"False",
+            "type":"Ready"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:11Z",
+            "reason":"PodCompleted",
+            "status":"False",
+            "type":"ContainersReady"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"True",
+            "type":"PodScheduled"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"True",
+            "type":"existingReadinessGateCondition"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"False",
+            "type":"existingReadinessGateCondition"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"True",
+            "type":"absentReadinessGateCondition"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"False",
+            "type":"absentReadinessGateCondition"
+         }
+      ],
+      "containerStatuses":[
+         {
+            "containerID": "docker://27e5a33803d1bf972d76ff701cf64169811167d5be9d4672ba265201b4811715",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                  "terminated": {
+                     "containerID": "docker://85c5a15d9c592ab65a74cc22c5ced1d5dd60d9d0a55390c045a93fad057a8099",
+                     "exitCode": 2,
+                     "finishedAt": "2024-08-15T03:40:38Z",
+                     "reason": "Error",
+                     "startedAt": "2024-08-14T14:00:37Z"
+                  }
+            },
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 1,
+            "started": true,
+            "state": {
+                  "running": {
+                     "startedAt": "2024-08-15T03:40:38Z"
+                  }
+            }
+         },
+         {
+            "containerID": "docker://6521895498486496",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+               "terminated": {
+                  "containerID": "docker://6521895498486496",
+                  "exitCode": 2,
+                  "finishedAt": "2024-08-15T03:40:38Z",
+                  "reason": "Error",
+                  "startedAt": "2024-08-14T14:00:37Z"
+               }
+            },
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 1,
+            "started": true,
+            "state": {
+               "running": {
+                  "startedAt": "2024-08-15T03:40:38Z"
+               }
+            }
+         },
+         {
+            "containerID": "docker://6884237457842122313290",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                "terminated": {
+                    "containerID": "docker://6884237457842122313290",
+                    "exitCode": 2,
+                    "finishedAt": "2024-08-15T03:40:38Z",
+                    "reason": "Error",
+                    "startedAt": "2024-08-14T14:00:37Z"
+                }
+            },
+            "name": "deployment-cluster-metrics",
+            "ready": true,
+            "restartCount": 3,
+            "started": true,
+            "state": {
+                "running": {
+                    "startedAt": "2024-08-15T03:40:38Z"
+                }
+            }
+         },
+         {
+            "containerID": "docker://6547986743222555",
+            "image": "otel/opentelemetry-collector-contrib:0.104.0",
+            "imageID": "docker-pullable://otel/opentelemetry-collector-contrib@sha256:e07e325e303e86f4a87a617491e921b579a92da6d404007394757ac910bf9587",
+            "lastState": {
+                "terminated": {
+                    "containerID": "docker://6547986743222555",
+                    "exitCode": 2,
+                    "finishedAt": "2024-08-15T03:40:38Z",
+                    "reason": "Error",
+                    "startedAt": "2024-08-14T14:00:37Z"
+                }
+            },
+            "name": "deployment-cluster-events",
+            "ready": false,
+            "restartCount": 0,
+            "started": true,
+            "state": {
+                "running": {
+                    "startedAt": "2024-08-15T03:40:38Z"
+                }
+            }
+         }
+      ],
+      "hostIP":"172.20.150.131",
+      "hostIPs":[
+         {
+            "ip":"172.20.150.131"
+         }
+      ],
+      "phase":"Succeeded",
+      "podIP":"172.20.141.129",
+      "podIPs":[
+         {
+            "ip":"172.20.141.129"
+         }
+      ],
+      "qosClass":"BestEffort",
+      "startTime":"2024-07-18T18:53:00Z"
+   }
+}

--- a/events.json
+++ b/events.json
@@ -1,0 +1,1897 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71519",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Successfully assigned observe/observe-agent-daemonset-logs-metrics-agent-v7fq6 to minikube",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b577bd3c0b1",
+                "namespace": "observe",
+                "resourceVersion": "71523",
+                "uid": "0b8aad82-8a0d-400d-a1ec-d0b166252e48"
+            },
+            "reason": "Scheduled",
+            "reportingComponent": "default-scheduler",
+            "reportingInstance": "",
+            "source": {
+                "component": "default-scheduler"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:56Z",
+            "message": "Pulling image \"observeinc/kube-cluster-info:v0.11.1\"",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b57994d3499",
+                "namespace": "observe",
+                "resourceVersion": "73370",
+                "uid": "9b022b3f-6a9d-479d-b5a7-c9c1db62a9cf"
+            },
+            "reason": "Pulling",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:05Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 972ms (2.681s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b5839266743",
+                "namespace": "observe",
+                "resourceVersion": "71580",
+                "uid": "4f925301-44b2-4076-bf3e-0e6467e4de3b"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:57Z",
+            "message": "Created container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b583a33416f",
+                "namespace": "observe",
+                "resourceVersion": "73374",
+                "uid": "94076183-ac72-4dd2-a235-ef68a0990630"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:56Z",
+            "message": "Started container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b583c4cc4a0",
+                "namespace": "observe",
+                "resourceVersion": "73201",
+                "uid": "4a35c9e6-b2e3-44e7-9349-11e30ebe681a"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:06Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:57Z",
+            "message": "Container image \"otel/opentelemetry-collector-contrib:0.104.0\" already present on machine",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:06Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b586c04f48a",
+                "namespace": "observe",
+                "resourceVersion": "73202",
+                "uid": "233be7d1-3a01-43e0-92d3-7a1299910b24"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:06Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:57Z",
+            "message": "Created container daemonset-logs-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:06Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b586d3f1b64",
+                "namespace": "observe",
+                "resourceVersion": "73203",
+                "uid": "2f8b74cd-7664-4393-b9b6-332b048d92da"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:06Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:57Z",
+            "message": "Started container daemonset-logs-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:06Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9b586f4b4e60",
+                "namespace": "observe",
+                "resourceVersion": "73204",
+                "uid": "00e0e838-5378-4a72-9d52-3fcfbbc7b68a"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.105:13133/\": dial tcp 10.244.120.105:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9cf5ff09bc2f",
+                "namespace": "observe",
+                "resourceVersion": "73121",
+                "uid": "7c4b880c-049b-4fe3-8fdb-567f9e3f6f97"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.105:13133/\": dial tcp 10.244.120.105:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9cf5ff09f5cd",
+                "namespace": "observe",
+                "resourceVersion": "73120",
+                "uid": "d51638db-7bc9-447c-b609-4df94e024bf3"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 5,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:49Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:56Z",
+            "message": "Pod sandbox changed, it will be killed and re-created.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9cf7a693a636",
+                "namespace": "observe",
+                "resourceVersion": "73368",
+                "uid": "141d90be-11cf-4f9a-8817-896b707b021c"
+            },
+            "reason": "SandboxChanged",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:56Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:56Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 950ms (2.864s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9cf928b01c22",
+                "namespace": "observe",
+                "resourceVersion": "73196",
+                "uid": "b3098308-8e34-44b3-8421-68e03c294a4a"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:32Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.111:13133/\": dial tcp 10.244.120.111:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9d0079386399",
+                "namespace": "observe",
+                "resourceVersion": "73325",
+                "uid": "3ce2fea5-ebce-417f-9686-666323548adb"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:27Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.111:13133/\": dial tcp 10.244.120.111:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9d007938a8c5",
+                "namespace": "observe",
+                "resourceVersion": "73301",
+                "uid": "2bc96e48-2439-4a13-8243-adee42181172"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:27Z",
+            "message": "Container daemonset-logs-metrics failed liveness probe, will be restarted",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9d007951bff2",
+                "namespace": "observe",
+                "resourceVersion": "73303",
+                "uid": "3149f9a7-6ba3-4837-ba17-be1ad68f64ca"
+            },
+            "reason": "Killing",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:57Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6",
+                "namespace": "observe",
+                "resourceVersion": "71521",
+                "uid": "37796797-38c6-4b8f-86cb-333cae3b674e"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:57Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 1.021s (1.021s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-v7fq6.17eb9d07672bc50f",
+                "namespace": "observe",
+                "resourceVersion": "73373",
+                "uid": "ec519f02-ed90-4884-9f45-17551f0e2c14"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{daemonset-logs-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-daemonset-logs-metrics-agent-w6czd",
+                "namespace": "observe",
+                "resourceVersion": "69700",
+                "uid": "86c96ab4-a9b3-4180-a6ed-aee75cfec94a"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Stopping container daemonset-logs-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent-w6czd.17eb9b5767f3e64b",
+                "namespace": "observe",
+                "resourceVersion": "71480",
+                "uid": "7587c878-0298-401d-8c28-727f60c76420"
+            },
+            "reason": "Killing",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "apps/v1",
+                "kind": "DaemonSet",
+                "name": "observe-agent-daemonset-logs-metrics-agent",
+                "namespace": "observe",
+                "resourceVersion": "69804",
+                "uid": "a8b7d242-efae-412c-b654-4018fd97a119"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Created pod: observe-agent-daemonset-logs-metrics-agent-v7fq6",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-daemonset-logs-metrics-agent.17eb9b577b5980cb",
+                "namespace": "observe",
+                "resourceVersion": "71520",
+                "uid": "839d7c9f-3c26-4739-8d9e-d4c2785d6636"
+            },
+            "reason": "SuccessfulCreate",
+            "reportingComponent": "daemonset-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "daemonset-controller"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71486",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Successfully assigned observe/observe-agent-deployment-cluster-events-578869d64b-9l4w2 to minikube",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b5768fa4afb",
+                "namespace": "observe",
+                "resourceVersion": "71490",
+                "uid": "c27b4ba4-42ef-4170-addb-e53a678c4eb8"
+            },
+            "reason": "Scheduled",
+            "reportingComponent": "default-scheduler",
+            "reportingInstance": "",
+            "source": {
+                "component": "default-scheduler"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:57Z",
+            "message": "Pulling image \"observeinc/kube-cluster-info:v0.11.1\"",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b5789106052",
+                "namespace": "observe",
+                "resourceVersion": "73372",
+                "uid": "17a5e653-28cf-4d93-a614-0a376a907657"
+            },
+            "reason": "Pulling",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:04Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 976ms (1.981s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b57ff2ed7b0",
+                "namespace": "observe",
+                "resourceVersion": "71568",
+                "uid": "042e818b-8941-4de8-a6e5-abd46e711f4a"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:54Z",
+            "message": "Created container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b580000d198",
+                "namespace": "observe",
+                "resourceVersion": "73174",
+                "uid": "dacd36d3-fbd8-4f34-ad95-1945e5bc2cd1"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:54Z",
+            "message": "Started container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b580247b57c",
+                "namespace": "observe",
+                "resourceVersion": "73175",
+                "uid": "a42e7ba4-a386-4273-871d-99f28e2c63cd"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:55Z",
+            "message": "Container image \"observe-agent:test-k8s\" already present on machine",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b582f286d24",
+                "namespace": "observe",
+                "resourceVersion": "73176",
+                "uid": "4f2d1c67-46a5-489b-9b94-2a6033c866f4"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:55Z",
+            "message": "Created container deployment-cluster-events",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b5830c9a786",
+                "namespace": "observe",
+                "resourceVersion": "73179",
+                "uid": "e797f211-84d4-4033-a73e-1244042f3db1"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:05Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:55Z",
+            "message": "Started container deployment-cluster-events",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:05Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9b583282da23",
+                "namespace": "observe",
+                "resourceVersion": "73181",
+                "uid": "5c543424-ff87-4e3e-9029-bdbfbc87f12f"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.107:13133/status\": dial tcp 10.244.120.107:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cf5ec342a3e",
+                "namespace": "observe",
+                "resourceVersion": "73116",
+                "uid": "9cd98f2b-fd2a-45a7-aebe-67104b05f8c6"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.107:13133/status\": dial tcp 10.244.120.107:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cf5ec35ca42",
+                "namespace": "observe",
+                "resourceVersion": "73115",
+                "uid": "ffb15dab-4564-47d3-b3e5-0339ccbe39a2"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 5,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:49Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:57Z",
+            "message": "Pod sandbox changed, it will be killed and re-created.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cf7a75a5e1f",
+                "namespace": "observe",
+                "resourceVersion": "73371",
+                "uid": "a3857da5-af7d-4056-8387-0381c7b721d5"
+            },
+            "reason": "SandboxChanged",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:54Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:54Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 1.081s (1.081s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cf8b6deea10",
+                "namespace": "observe",
+                "resourceVersion": "73173",
+                "uid": "ef8822a0-cb56-4600-8126-e34372b78db9"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:22Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:32Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.106:13133/status\": dial tcp 10.244.120.106:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cff3c68b7b6",
+                "namespace": "observe",
+                "resourceVersion": "73314",
+                "uid": "f7d19482-b88d-4755-ba18-e8c07a05837f"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:22Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:32Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.106:13133/status\": dial tcp 10.244.120.106:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9cff3c6bce3d",
+                "namespace": "observe",
+                "resourceVersion": "73313",
+                "uid": "e12bfdcb-d88f-4c0d-ae7a-67c9ba31f531"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:32Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+                "namespace": "observe",
+                "resourceVersion": "71488",
+                "uid": "6e40db9d-7848-4ea7-a720-349db27cf6e9"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:32Z",
+            "message": "error determining status: rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: read unix @-\u003e/run/cri-dockerd.sock: read: connection reset by peer\"",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-9l4w2.17eb9d01906e8f8d",
+                "namespace": "observe",
+                "resourceVersion": "73315",
+                "uid": "64a83dd1-fd66-409d-b272-36f9fb323aa8"
+            },
+            "reason": "FailedSync",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-events}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-f8dkf",
+                "namespace": "observe",
+                "resourceVersion": "69668",
+                "uid": "26f4cec3-019b-451a-8082-e959842d97ef"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Stopping container deployment-cluster-events",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-f8dkf.17eb9b576652ff3e",
+                "namespace": "observe",
+                "resourceVersion": "71459",
+                "uid": "5a0caba6-bd72-43b6-a762-50697d209594"
+            },
+            "reason": "Killing",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-vfcs4",
+                "namespace": "observe",
+                "resourceVersion": "71461",
+                "uid": "a3dd90b9-7d2a-4b4f-92c9-ba8564b3516c"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Successfully assigned observe/observe-agent-deployment-cluster-events-578869d64b-vfcs4 to minikube",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b-vfcs4.17eb9b57671952ba",
+                "namespace": "observe",
+                "resourceVersion": "71473",
+                "uid": "053c460f-841b-4878-b6f2-570a9f726d18"
+            },
+            "reason": "Scheduled",
+            "reportingComponent": "default-scheduler",
+            "reportingInstance": "",
+            "source": {
+                "component": "default-scheduler"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "name": "observe-agent-deployment-cluster-events-578869d64b",
+                "namespace": "observe",
+                "resourceVersion": "69778",
+                "uid": "da6eee48-3603-4377-9529-7a877095e9ca"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Created pod: observe-agent-deployment-cluster-events-578869d64b-vfcs4",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b.17eb9b5766cdebfe",
+                "namespace": "observe",
+                "resourceVersion": "71467",
+                "uid": "fc56a865-268c-4abd-99d0-3882cfd1ce57"
+            },
+            "reason": "SuccessfulCreate",
+            "reportingComponent": "replicaset-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "replicaset-controller"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "name": "observe-agent-deployment-cluster-events-578869d64b",
+                "namespace": "observe",
+                "resourceVersion": "71481",
+                "uid": "da6eee48-3603-4377-9529-7a877095e9ca"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Created pod: observe-agent-deployment-cluster-events-578869d64b-9l4w2",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-events-578869d64b.17eb9b5768dd8666",
+                "namespace": "observe",
+                "resourceVersion": "71487",
+                "uid": "661b1514-4ac9-431c-ad5a-b67642188938"
+            },
+            "reason": "SuccessfulCreate",
+            "reportingComponent": "replicaset-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "replicaset-controller"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71494",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Successfully assigned observe/observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg to minikube",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57699be737",
+                "namespace": "observe",
+                "resourceVersion": "71502",
+                "uid": "77c975ca-8fcb-4651-b7cc-ddcb779441a1"
+            },
+            "reason": "Scheduled",
+            "reportingComponent": "default-scheduler",
+            "reportingInstance": "",
+            "source": {
+                "component": "default-scheduler"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:59:03Z",
+            "message": "Pulling image \"observeinc/kube-cluster-info:v0.11.1\"",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b578852062e",
+                "namespace": "observe",
+                "resourceVersion": "73396",
+                "uid": "9fc93c2d-dfef-4718-b359-7deef7abfcd5"
+            },
+            "reason": "Pulling",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:03Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:03Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 1.018s (1.018s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:03Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57c5016873",
+                "namespace": "observe",
+                "resourceVersion": "71558",
+                "uid": "1591eca9-0da9-49a8-ad9b-2e11e5260211"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:03Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:59:04Z",
+            "message": "Created container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:03Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57c628435c",
+                "namespace": "observe",
+                "resourceVersion": "73399",
+                "uid": "9f738eb4-c884-4e2f-929b-8600627e1406"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:03Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:55Z",
+            "message": "Started container kube-cluster-info",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:03Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57c8531701",
+                "namespace": "observe",
+                "resourceVersion": "73184",
+                "uid": "ef383415-2892-4cd2-ae9b-278a05ca0294"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:56Z",
+            "message": "Container image \"otel/opentelemetry-collector-contrib:0.104.0\" already present on machine",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57f25c13ab",
+                "namespace": "observe",
+                "resourceVersion": "73193",
+                "uid": "b2c9d23a-36c6-403e-88f9-30fece65c550"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:56Z",
+            "message": "Created container deployment-cluster-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57f474f6b3",
+                "namespace": "observe",
+                "resourceVersion": "73195",
+                "uid": "c62de7ed-00ba-411b-9836-b4c02dcf4e0d"
+            },
+            "reason": "Created",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:56Z",
+            "message": "Started container deployment-cluster-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:04Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9b57f72b6f88",
+                "namespace": "observe",
+                "resourceVersion": "73199",
+                "uid": "f94868eb-5d89-46e4-a715-0755eaebb903"
+            },
+            "reason": "Started",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.104:13133/\": dial tcp 10.244.120.104:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9cf5f128e45a",
+                "namespace": "observe",
+                "resourceVersion": "73117",
+                "uid": "14012067-3873-4666-b635-e24906af5658"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 2,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:42Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:47Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.104:13133/\": dial tcp 10.244.120.104:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9cf5f12b8822",
+                "namespace": "observe",
+                "resourceVersion": "73118",
+                "uid": "ca6e2b31-a4d7-4dc2-a34b-77b4b9f0462d"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 5,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:49Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:59:03Z",
+            "message": "Pod sandbox changed, it will be killed and re-created.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9cf7aaf72f36",
+                "namespace": "observe",
+                "resourceVersion": "73386",
+                "uid": "96d4aae6-8eee-4ab6-9944-316292194c2a"
+            },
+            "reason": "SandboxChanged",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:57:55Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:57:55Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 959ms (1.96s including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:58:00Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9cf8f00e9763",
+                "namespace": "observe",
+                "resourceVersion": "73182",
+                "uid": "2c0e8276-7235-4d32-a0f7-73c664c59413"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 3,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:32Z",
+            "message": "Readiness probe failed: Get \"http://10.244.120.108:13133/\": dial tcp 10.244.120.108:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9d006b71d324",
+                "namespace": "observe",
+                "resourceVersion": "73316",
+                "uid": "5daf8115-6cde-4fb2-9695-240c337ded71"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:27Z",
+            "message": "Liveness probe failed: Get \"http://10.244.120.108:13133/\": dial tcp 10.244.120.108:13133: connect: invalid argument",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9d006b71d377",
+                "namespace": "observe",
+                "resourceVersion": "73296",
+                "uid": "73fd755b-e930-4f08-a57e-6c99972cc17d"
+            },
+            "reason": "Unhealthy",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Warning"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:58:27Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:58:27Z",
+            "message": "Container deployment-cluster-metrics failed liveness probe, will be restarted",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9d006b888315",
+                "namespace": "observe",
+                "resourceVersion": "73299",
+                "uid": "d51db0ea-8cd2-4e89-8905-721de4c8a8d3"
+            },
+            "reason": "Killing",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:59:04Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.initContainers{kube-cluster-info}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+                "namespace": "observe",
+                "resourceVersion": "71496",
+                "uid": "9fcd5dc2-b325-49ce-8556-cce7fd5449d7"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:59:04Z",
+            "message": "Successfully pulled image \"observeinc/kube-cluster-info:v0.11.1\" in 971ms (971ms including waiting). Image size: 19308076 bytes.",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:04Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg.17eb9d0900c7b8b2",
+                "namespace": "observe",
+                "resourceVersion": "73398",
+                "uid": "c66fb44e-16fd-4e02-8ba4-081a6dd1ff18"
+            },
+            "reason": "Pulled",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.containers{deployment-cluster-metrics}",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-c4kp9",
+                "namespace": "observe",
+                "resourceVersion": "69677",
+                "uid": "8d977039-3501-4224-8b3f-3b9c105435c3"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Stopping container deployment-cluster-metrics",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-c4kp9.17eb9b5766ab5433",
+                "namespace": "observe",
+                "resourceVersion": "71464",
+                "uid": "776369f1-031a-4ee0-a5e1-5dcaf163a8d6"
+            },
+            "reason": "Killing",
+            "reportingComponent": "kubelet",
+            "reportingInstance": "minikube",
+            "source": {
+                "component": "kubelet",
+                "host": "minikube"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-lzc9l",
+                "namespace": "observe",
+                "resourceVersion": "71466",
+                "uid": "cb91f7c2-c4c5-4975-9d95-5541d165a5be"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Successfully assigned observe/observe-agent-deployment-cluster-metrics-c9b5df57f-lzc9l to minikube",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f-lzc9l.17eb9b57674b3ed6",
+                "namespace": "observe",
+                "resourceVersion": "71475",
+                "uid": "64719dd7-3af4-494b-859f-6c787f0b00fe"
+            },
+            "reason": "Scheduled",
+            "reportingComponent": "default-scheduler",
+            "reportingInstance": "",
+            "source": {
+                "component": "default-scheduler"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f",
+                "namespace": "observe",
+                "resourceVersion": "69801",
+                "uid": "51daa305-0328-48fe-9a30-ed5a321d52e3"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Created pod: observe-agent-deployment-cluster-metrics-c9b5df57f-lzc9l",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f.17eb9b5766fc5d51",
+                "namespace": "observe",
+                "resourceVersion": "71472",
+                "uid": "8362aa8f-78c2-4e0b-bc97-11e1938a0a43"
+            },
+            "reason": "SuccessfulCreate",
+            "reportingComponent": "replicaset-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "replicaset-controller"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:28:02Z",
+            "involvedObject": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f",
+                "namespace": "observe",
+                "resourceVersion": "71477",
+                "uid": "51daa305-0328-48fe-9a30-ed5a321d52e3"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:28:02Z",
+            "message": "Created pod: observe-agent-deployment-cluster-metrics-c9b5df57f-6f6gg",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:28:02Z",
+                "name": "observe-agent-deployment-cluster-metrics-c9b5df57f.17eb9b57697262cc",
+                "namespace": "observe",
+                "resourceVersion": "71497",
+                "uid": "b74fafe6-915d-430b-9d77-54aaf161e862"
+            },
+            "reason": "SuccessfulCreate",
+            "reportingComponent": "replicaset-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "replicaset-controller"
+            },
+            "type": "Normal"
+        },
+        {
+            "apiVersion": "v1",
+            "count": 1,
+            "eventTime": null,
+            "firstTimestamp": "2024-08-14T13:59:17Z",
+            "involvedObject": {
+                "apiVersion": "v1",
+                "kind": "Endpoints",
+                "name": "observe-agent-deployment-cluster-metrics",
+                "namespace": "observe",
+                "resourceVersion": "73220",
+                "uid": "ca884d54-c9c4-42b2-a353-da0785e9f221"
+            },
+            "kind": "Event",
+            "lastTimestamp": "2024-08-14T13:59:17Z",
+            "message": "Failed to update endpoint observe/observe-agent-deployment-cluster-metrics: Operation cannot be fulfilled on endpoints \"observe-agent-deployment-cluster-metrics\": the object has been modified; please apply your changes to the latest version and try again",
+            "metadata": {
+                "creationTimestamp": "2024-08-14T13:59:17Z",
+                "name": "observe-agent-deployment-cluster-metrics.17eb9d0c19daa18e",
+                "namespace": "observe",
+                "resourceVersion": "73436",
+                "uid": "1d49839c-a719-4b27-a840-f75985988cec"
+            },
+            "reason": "FailedToUpdateEndpoint",
+            "reportingComponent": "endpoint-controller",
+            "reportingInstance": "",
+            "source": {
+                "component": "endpoint-controller"
+            },
+            "type": "Warning"
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}


### PR DESCRIPTION
Add "Status" and "Roles" facets

Rework the testing a bit to allow using jmespath to query specific fields of interest instead of manually creating json-like objects in go to exactly match the output.

### Description

This PR adds the "Roles" and "Status" facets to Node.
Since "Roles" is an array, I had to change the interface of the existing `ValueFn()` to return `any` instead of `string`, so that we can return maps and arrays, too.

The current testing process is a bit cumbersome and doesn't scale well, since we are making a single `pcommon.Logs` containing all testing input logs, and then we have to maintain a parallel slice of "desired outputs", correlating inLogs[i] with outResults[i]. Since the correlation is always 1:1, I figured I could change this to:
each testcase contains a single `pcommon.Logs`, which contains only ONE Log. And each testcase also contains whatever verification(s) we want for the processed output of such log. Then we simply iterate over the testcases.
I also got rid of all manually-created `map[string]interface{}` json-like madness and used `jmespath`, which allows for simpler and more powerful queries, so that we can selectively test what we need from the processed Logs!
Given that we don't do correlation between logs, I figured that the assumption of always having a single log both as input and as output of the processor is enough for what we are doing here.

### Checklist
- [ ] Created tests which fail without the change (if possible) --> not possible, this is modular
- [ ] Extended the README / documentation, if necessary