### PR TITLE
feat: split process metrics out of host metrics

### DIFF
--- a/cmd/commands/initconfig/configschema.go
+++ b/cmd/commands/initconfig/configschema.go
@@ -4,8 +4,17 @@ type HostMonitoringLogsConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type HostMonitoringMetricsConfig struct {
+type HostMonitoringHostMetricsConfig struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+type HostMonitoringProcessMetricsConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type HostMonitoringMetricsConfig struct {
+	Host    HostMonitoringHostMetricsConfig
+	Process HostMonitoringProcessMetricsConfig
 }
 
 type HostMonitoringConfig struct {

--- a/cmd/commands/initconfig/initconfig.go
+++ b/cmd/commands/initconfig/initconfig.go
@@ -15,13 +15,14 @@ import (
 )
 
 var (
-	config_path                     string
-	token                           string
-	observe_url                     string
-	self_monitoring_enabled         bool
-	host_monitoring_enabled         bool
-	host_monitoring_logs_enabled    bool
-	host_monitoring_metrics_enabled bool
+	config_path                             string
+	token                                   string
+	observe_url                             string
+	self_monitoring_enabled                 bool
+	host_monitoring_enabled                 bool
+	host_monitoring_logs_enabled            bool
+	host_monitoring_metrics_host_enabled    bool
+	host_monitoring_metrics_process_enabled bool
 	//go:embed observe-agent.tmpl
 	configTemplateFS embed.FS
 )
@@ -29,12 +30,13 @@ var (
 const configTemplate = "observe-agent.tmpl"
 
 type FlatAgentConfig struct {
-	Token                         string
-	ObserveURL                    string
-	SelfMonitoring_Enabled        bool
-	HostMonitoring_Enabled        bool
-	HostMonitoring_LogsEnabled    bool
-	HostMonitoring_MetricsEnabled bool
+	Token                                 string
+	ObserveURL                            string
+	SelfMonitoring_Enabled                bool
+	HostMonitoring_Enabled                bool
+	HostMonitoring_LogsEnabled            bool
+	HostMonitoring_Metrics_HostEnabled    bool
+	HostMonitoring_Metrics_ProcessEnabled bool
 }
 
 func NewConfigureCmd() *cobra.Command {
@@ -44,12 +46,13 @@ func NewConfigureCmd() *cobra.Command {
 		Long:  `This command takes in parameters and creates an initialized observe agent configuration file. Will overwrite existing config file and should only be used to initialize.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configValues := FlatAgentConfig{
-				Token:                         viper.GetString("token"),
-				ObserveURL:                    viper.GetString("observe_url"),
-				SelfMonitoring_Enabled:        viper.GetBool("self_monitoring::enabled"),
-				HostMonitoring_Enabled:        viper.GetBool("host_monitoring::enabled"),
-				HostMonitoring_LogsEnabled:    viper.GetBool("host_monitoring::logs::enabled"),
-				HostMonitoring_MetricsEnabled: viper.GetBool("host_monitoring::metrics::enabled"),
+				Token:                                 viper.GetString("token"),
+				ObserveURL:                            viper.GetString("observe_url"),
+				SelfMonitoring_Enabled:                viper.GetBool("self_monitoring::enabled"),
+				HostMonitoring_Enabled:                viper.GetBool("host_monitoring::enabled"),
+				HostMonitoring_LogsEnabled:            viper.GetBool("host_monitoring::logs::enabled"),
+				HostMonitoring_Metrics_HostEnabled:    viper.GetBool("host_monitoring::metrics::host::enabled"),
+				HostMonitoring_Metrics_ProcessEnabled: viper.GetBool("host_monitoring::metrics::process::enabled"),
 			}
 			var outputPath string
 			if config_path != "" {
@@ -85,11 +88,13 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&self_monitoring_enabled, "self_monitoring::enabled", true, "Enable self monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_enabled, "host_monitoring::enabled", true, "Enable host monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_logs_enabled, "host_monitoring::logs::enabled", true, "Enable host monitoring logs")
-	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_enabled, "host_monitoring::metrics::enabled", true, "Enable host monitoring metrics")
+	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_host_enabled, "host_monitoring::metrics::host::enabled", true, "Enable host monitoring host metrics")
+	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_process_enabled, "host_monitoring::metrics::process::enabled", false, "Enable host monitoring process metrics")
 	viper.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
 	viper.BindPFlag("observe_url", cmd.PersistentFlags().Lookup("observe_url"))
 	viper.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))
-	viper.BindPFlag("host_monitoring::metrics::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::enabled"))
+	viper.BindPFlag("host_monitoring::metrics::host::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::host::enabled"))
+	viper.BindPFlag("host_monitoring::metrics::process::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::process::enabled"))
 }

--- a/cmd/commands/initconfig/initconfig_test.go
+++ b/cmd/commands/initconfig/initconfig_test.go
@@ -31,14 +31,19 @@ func Test_InitConfigCommand(t *testing.T) {
 						Enabled: true,
 					},
 					Metrics: HostMonitoringMetricsConfig{
-						Enabled: true,
+						Host: HostMonitoringHostMetricsConfig{
+							Enabled: true,
+						},
+						Process: HostMonitoringProcessMetricsConfig{
+							Enabled: false,
+						},
 					},
 				},
 			},
 			expectErr: "",
 		},
 		{
-			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url", "--self_monitoring::enabled=false", "--host_monitoring::enabled=false", "--host_monitoring::logs::enabled=false", "--host_monitoring::metrics::enabled=false"},
+			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url", "--self_monitoring::enabled=false", "--host_monitoring::enabled=false", "--host_monitoring::logs::enabled=false", "--host_monitoring::metrics::host::enabled=false", "--host_monitoring::metrics::process::enabled=false"},
 			expectedConfig: AgentConfig{
 				Token:      "test-token",
 				ObserveURL: "test-url",
@@ -48,7 +53,12 @@ func Test_InitConfigCommand(t *testing.T) {
 						Enabled: false,
 					},
 					Metrics: HostMonitoringMetricsConfig{
-						Enabled: false,
+						Host: HostMonitoringHostMetricsConfig{
+							Enabled: false,
+						},
+						Process: HostMonitoringProcessMetricsConfig{
+							Enabled: false,
+						},
 					},
 				},
 			},

--- a/cmd/commands/initconfig/observe-agent.tmpl
+++ b/cmd/commands/initconfig/observe-agent.tmpl
@@ -15,7 +15,10 @@ host_monitoring:
   logs: 
     enabled: {{ .HostMonitoring_LogsEnabled }}
   metrics:
-    enabled: {{ .HostMonitoring_MetricsEnabled }}
+    host:
+      enabled: {{ .HostMonitoring_Metrics_HostEnabled }}
+    process:
+      enabled: {{ .HostMonitoring_Metrics_ProcessEnabled }}
 
 # otel_config_overrides:
 #   exporters:

--- a/cmd/connections/hostmonitoring.go
+++ b/cmd/connections/hostmonitoring.go
@@ -19,7 +19,15 @@ var HostMonitoringConnectionType = ConnectionType{
 		},
 		{
 			configYAMLPath:    "metrics::enabled",
-			colConfigFilePath: "metrics.yaml",
+			colConfigFilePath: "host_metrics.yaml",
+		},
+		{
+			configYAMLPath:    "metrics::host::enabled",
+			colConfigFilePath: "host_metrics.yaml",
+		},
+		{
+			configYAMLPath:    "metrics::process::enabled",
+			colConfigFilePath: "process_metrics.yaml",
 		},
 		{
 			configYAMLPath:    "logs::enabled",

--- a/packaging/docker/observe-agent/connections/host_monitoring/host_metrics.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/host_metrics.yaml
@@ -1,6 +1,6 @@
 receivers:
-  hostmetrics/host-monitoring:
-    collection_interval: 20s
+  hostmetrics/host-monitoring-host:
+    collection_interval: 60s
     root_path: /hostfs
     scrapers:
       cpu:
@@ -31,32 +31,10 @@ receivers:
           system.paging.utilization:
             enabled: true
       processes:
-      process:
-        metrics:
-          process.context_switches:
-            enabled: true
-          process.cpu.utilization:
-            enabled: true
-          process.disk.operations:
-            enabled: true      
-          process.memory.utilization:
-            enabled: true      
-          process.open_file_descriptors:
-            enabled: true      
-          process.paging.faults:
-            enabled: true      
-          process.signals_pending:
-            enabled: true      
-          process.threads:
-            enabled: true
-        mute_process_name_error: true
-        mute_process_exe_error: true
-        mute_process_io_error: true
-        mute_process_user_error: true
 
 service:
   pipelines:
-    metrics/host_monitoring:
-      receivers: [hostmetrics/host-monitoring]
+    metrics/host_monitoring_host:
+      receivers: [hostmetrics/host-monitoring-host]
       processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe]

--- a/packaging/docker/observe-agent/connections/host_monitoring/process_metrics.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/process_metrics.yaml
@@ -1,35 +1,8 @@
 receivers:
-  hostmetrics/host-monitoring:
-    collection_interval: 20s
+  hostmetrics/host-monitoring-process:
+    collection_interval: 60s
+    root_path: /hostfs
     scrapers:
-      cpu:
-        metrics:
-          system.cpu.utilization:
-            enabled: true
-          system.cpu.frequency:
-            enabled: true
-          system.cpu.logical.count:
-            enabled: true
-          system.cpu.physical.count:
-            enabled: true
-      load:
-      memory:
-        metrics:
-          system.memory.utilization:
-            enabled: true
-          system.linux.memory.available:
-            enabled: true
-      disk:
-      filesystem:
-        metrics:
-          system.filesystem.utilization:
-            enabled: true
-      network:
-      paging:
-        metrics:
-          system.paging.utilization:
-            enabled: true
-      processes:
       process:
         metrics:
           process.context_switches:
@@ -55,7 +28,7 @@ receivers:
 
 service:
   pipelines:
-    metrics/host_monitoring:
-      receivers: [hostmetrics/host-monitoring]
+    metrics/host_monitoring_process:
+      receivers: [hostmetrics/host-monitoring-process]
       processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe]

--- a/packaging/linux/config/observe-agent.yaml
+++ b/packaging/linux/config/observe-agent.yaml
@@ -15,7 +15,10 @@ host_monitoring:
   logs: 
     enabled: true
   metrics:
-    enabled: true
+    host:
+      enabled: true
+    process:
+      enabled: false
     
 # otel_config_overrides:
 #   exporters:

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/host_metrics.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/host_metrics.yaml
@@ -1,0 +1,39 @@
+receivers:
+  hostmetrics/host-monitoring-host:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+          system.cpu.frequency:
+            enabled: true
+          system.cpu.logical.count:
+            enabled: true
+          system.cpu.physical.count:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+          system.linux.memory.available:
+            enabled: true
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      network:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      processes:
+
+service:
+  pipelines:
+    metrics/host_monitoring_host:
+      receivers: [hostmetrics/host-monitoring-host]
+      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [otlphttp/observe]

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/process_metrics.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/process_metrics.yaml
@@ -1,0 +1,33 @@
+receivers:
+  hostmetrics/host-monitoring-process:
+    collection_interval: 60s
+    scrapers:
+      process:
+        metrics:
+          process.context_switches:
+            enabled: true
+          process.cpu.utilization:
+            enabled: true
+          process.disk.operations:
+            enabled: true      
+          process.memory.utilization:
+            enabled: true      
+          process.open_file_descriptors:
+            enabled: true      
+          process.paging.faults:
+            enabled: true      
+          process.signals_pending:
+            enabled: true      
+          process.threads:
+            enabled: true
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+
+service:
+  pipelines:
+    metrics/host_monitoring_process:
+      receivers: [hostmetrics/host-monitoring-process]
+      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [otlphttp/observe]

--- a/packaging/windows/connections/host_monitoring/host_metrics.yaml
+++ b/packaging/windows/connections/host_monitoring/host_metrics.yaml
@@ -1,6 +1,6 @@
 receivers:
-  hostmetrics/host-monitoring:
-    collection_interval: 20s
+  hostmetrics/host-monitoring-host:
+    collection_interval: 60s
     scrapers:
       cpu:
         metrics:
@@ -24,7 +24,7 @@ receivers:
 
 service:
   pipelines:
-    metrics/host_monitoring:
-      receivers: [hostmetrics/host-monitoring]
+    metrics/host_monitoring_host:
+      receivers: [hostmetrics/host-monitoring-host]
       processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
       exporters: [otlphttp/observe]

--- a/packaging/windows/connections/host_monitoring/process_metrics.yaml
+++ b/packaging/windows/connections/host_monitoring/process_metrics.yaml
@@ -1,0 +1,33 @@
+receivers:
+  hostmetrics/host-monitoring-process:
+    collection_interval: 60s
+    scrapers:
+      process:
+        metrics:
+          process.context_switches:
+            enabled: true
+          process.cpu.utilization:
+            enabled: true
+          process.disk.operations:
+            enabled: true      
+          process.memory.utilization:
+            enabled: true      
+          process.open_file_descriptors:
+            enabled: true      
+          process.paging.faults:
+            enabled: true      
+          process.signals_pending:
+            enabled: true      
+          process.threads:
+            enabled: true
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+
+service:
+  pipelines:
+    metrics/host_monitoring_process:
+      receivers: [hostmetrics/host-monitoring-process]
+      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [otlphttp/observe]

--- a/packaging/windows/observe-agent.yaml
+++ b/packaging/windows/observe-agent.yaml
@@ -15,7 +15,10 @@ host_monitoring:
   logs: 
     enabled: true
   metrics:
-    enabled: true
+    host:
+      enabled: true
+    process:
+      enabled: false
     
 # otel_config_overrides:
 #   exporters:


### PR DESCRIPTION
### Description

OB-34900 Split process level metrics collection out of host_monitoring metrics and default to off. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary