### PR TITLE
Refactor processor actions

### DIFF
--- a/components/processors/observek8sattributesprocessor/node.go
+++ b/components/processors/observek8sattributesprocessor/node.go
@@ -1,5 +1,0 @@
-package observek8sattributesprocessor
-
-func filterNodeEvents(event K8sEvent) bool {
-	return event.Kind == "Node"
-}

--- a/components/processors/observek8sattributesprocessor/noderoles.go
+++ b/components/processors/observek8sattributesprocessor/noderoles.go
@@ -1,13 +1,8 @@
 package observek8sattributesprocessor
 
 import (
-	"encoding/json"
-	"errors"
-
 	"strings"
 
-	"go.opentelemetry.io/collector/pdata/plog"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -20,18 +15,17 @@ const (
 	nodeLabelRole = "kubernetes.io/role"
 )
 
-var NodeRolesAction = K8sEventProcessorAction{
-	ComputeAttributes: getNodeRoles,
-	// Reuse the function to filter events for nodes
-	FilterFn: filterNodeEvents,
+type NodeRolesAction struct{}
+
+func NewNodeRolesAction() NodeRolesAction {
+	return NodeRolesAction{}
 }
 
 // Generates the Node "status" facet. Assumes that objLog is a log from a Node event.
-func getNodeRoles(objLog plog.LogRecord) (attributes, error) {
-	var node v1.Node
-	err := json.Unmarshal([]byte(objLog.Body().AsString()), &node)
+func (NodeRolesAction) ComputeAttributes(obj any) (attributes, error) {
+	node, err := getNode(obj)
 	if err != nil {
-		return nil, errors.New("could not unmarshal Node")
+		return nil, err
 	}
 	// based on https://github.com/kubernetes/kubernetes/blob/dbc2b0a5c7acc349ea71a14e49913661eaf708d2/pkg/printers/internalversion/printers.go#L183https://github.com/kubernetes/kubernetes/blob/1e12d92a5179dbfeb455c79dbf9120c8536e5f9c/pkg/printers/internalversion/printers.go#L14875
 	roles := sets.NewString()

--- a/components/processors/observek8sattributesprocessor/pod.go
+++ b/components/processors/observek8sattributesprocessor/pod.go
@@ -1,5 +1,0 @@
-package observek8sattributesprocessor
-
-func filterPodEvents(event K8sEvent) bool {
-	return event.Kind == "Pod"
-}

--- a/components/processors/observek8sattributesprocessor/podconditions.go
+++ b/components/processors/observek8sattributesprocessor/podconditions.go
@@ -1,0 +1,33 @@
+package observek8sattributesprocessor
+
+const (
+	// This action will be ignored and not written in any of the facets, since
+	// we return map[string]any
+	PodConditionsAttributeKey = "conditions"
+)
+
+// Gather all Pod conditions into a single facet named "conditions"
+// (with actual type: map[string]bool)
+type PodConditionsAction struct{}
+
+func NewPodConditionsAction() PodConditionsAction {
+	return PodConditionsAction{}
+}
+
+func (PodConditionsAction) ComputeAttributes(obj any) (attributes, error) {
+	pod, err := getPod(obj)
+	if err != nil {
+		return nil, err
+	}
+	conditions := attributes{}
+	for _, cond := range pod.Status.Conditions {
+		// Assumes that k8s doesn't return multiple conditions of the same type.
+		// If that were to happen, we just overwrite the previous ones
+		conditions[string(cond.Type)] = string(cond.Status)
+	}
+
+	// return a map[string]any with a single value.
+	// The key is the name of the face (and of this action),
+	// This facet's value is a map itself with k-v pairs, keyed with strings
+	return attributes{PodConditionsAttributeKey: conditions}, nil
+}

--- a/components/processors/observek8sattributesprocessor/podreadiness.go
+++ b/components/processors/observek8sattributesprocessor/podreadiness.go
@@ -1,10 +1,6 @@
 package observek8sattributesprocessor
 
 import (
-	"encoding/json"
-	"errors"
-
-	"go.opentelemetry.io/collector/pdata/plog"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -20,16 +16,16 @@ const (
 //
 // We compute more facets into a single action to avoid iterating over the
 // same slice multiple times in different actions.
-var PodReadinessAction = K8sEventProcessorAction{
-	ComputeAttributes: getPodReadiness,
-	FilterFn:          filterPodEvents,
+type PodReadinessAction struct{}
+
+func NewPodReadinessAction() PodReadinessAction {
+	return PodReadinessAction{}
 }
 
-func getPodReadiness(objLog plog.LogRecord) (attributes, error) {
-	var pod v1.Pod
-	err := json.Unmarshal([]byte(objLog.Body().AsString()), &pod)
+func (PodReadinessAction) ComputeAttributes(obj any) (attributes, error) {
+	pod, err := getPod(obj)
 	if err != nil {
-		return nil, errors.New("could not unmarshal Pod")
+		return nil, err
 	}
 	readinessGatesReady := 0
 

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -132,12 +132,13 @@ func TestK8sEventsProcessor(t *testing.T) {
 			),
 			expectedResults: []queryWithResult{
 				// Conditions must be a map with 5 elements
-				{"observe_transform.facets.conditions | length(@)", float64(5)},
-				{"observe_transform.facets.conditions.PodReadyToStartContainers", false},
-				{"observe_transform.facets.conditions.Initialized", true},
-				{"observe_transform.facets.conditions.Ready", false},
-				{"observe_transform.facets.conditions.ContainersReady", false},
-				{"observe_transform.facets.conditions.PodScheduled", true},
+				{"observe_transform.facets.conditions | length(@)", float64(6)},
+				{"observe_transform.facets.conditions.PodReadyToStartContainers", "False"},
+				{"observe_transform.facets.conditions.Initialized", "True"},
+				{"observe_transform.facets.conditions.Ready", "False"},
+				{"observe_transform.facets.conditions.ContainersReady", "False"},
+				{"observe_transform.facets.conditions.PodScheduled", "True"},
+				{"observe_transform.facets.conditions.TestCondition", "Unknown"},
 			},
 		},
 	} {

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -123,6 +123,23 @@ func TestK8sEventsProcessor(t *testing.T) {
 				{"observe_transform.facets.readinessGatesTotal", int64(2)},
 			},
 		},
+		{
+			name: "Pod conditions",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/podObjectEvent.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				// Conditions must be a map with 5 elements
+				{"observe_transform.facets.conditions | length(@)", float64(5)},
+				{"observe_transform.facets.conditions.PodReadyToStartContainers", false},
+				{"observe_transform.facets.conditions.Initialized", true},
+				{"observe_transform.facets.conditions.Ready", false},
+				{"observe_transform.facets.conditions.ContainersReady", false},
+				{"observe_transform.facets.conditions.PodScheduled", true},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			kep := newK8sEventsProcessor(zap.NewNop(), &Config{})

--- a/components/processors/observek8sattributesprocessor/testdata/podObjectEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/podObjectEvent.json
@@ -509,6 +509,12 @@
             "lastTransitionTime":"2024-07-18T18:53:00Z",
             "status":"True",
             "type":"PodScheduled"
+         },
+         {
+            "lastProbeTime":null,
+            "lastTransitionTime":"2024-07-18T18:53:00Z",
+            "status":"Unknown",
+            "type":"TestCondition"
          }
       ],
       "containerStatuses":[

--- a/components/processors/observek8sattributesprocessor/types.go
+++ b/components/processors/observek8sattributesprocessor/types.go
@@ -1,0 +1,44 @@
+package observek8sattributesprocessor
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type K8sEvent struct {
+	Kind       string `json:"kind,omitempty"`
+	ApiVersion string `json:"apiVersion,omitempty"`
+}
+
+type attributes map[string]any
+
+// Action that processes a K8S object and computes custom attributes for it
+type K8sEventProcessorAction interface {
+	// Computes attributes for a k8s entity.  Since entities like Pod, Node,
+	// etc. don't have a common interface, the argument of ComputeAttributes is
+	// of type any types that implement this method should check that the arg is
+	// of the right type before proceeding.
+	// Check the utility functions below for more info
+	ComputeAttributes(any) (attributes, error)
+}
+
+// Type asserts obj to v1.Node, returning an error if the underlying concrete
+// value is not of type Node
+func getNode(obj any) (v1.Node, error) {
+	node, ok := obj.(v1.Node)
+	if !ok {
+		return node, fmt.Errorf("cannot convert %v to Node", obj)
+	}
+	return node, nil
+}
+
+// Type asserts obj to v1.Pod, returning an error if the underlying concrete
+// value is not of type Pod
+func getPod(obj any) (v1.Pod, error) {
+	pod, ok := obj.(v1.Pod)
+	if !ok {
+		return pod, fmt.Errorf("cannot convert %v to Pod", obj)
+	}
+	return pod, nil
+}


### PR DESCRIPTION
Refactor processor actions to improve efficiency
- Unmarshal each event only once rather than once per action!
- Separate NodeActions and PodActions.
- For each event, call ComputeAttributes only on those actions that are able to process such event type!

Add Pod facet "conditions"