### PR TITLE
OB-35830 Add Node "nodePool" facet

### DIFF
--- a/components/processors/observek8sattributesprocessor/nodepool.go
+++ b/components/processors/observek8sattributesprocessor/nodepool.go
@@ -1,0 +1,37 @@
+package observek8sattributesprocessor
+
+const (
+	NodePoolAttributeKey = "nodePool"
+)
+
+type NodePoolAction struct{}
+
+func NewNodePoolAction() NodePoolAction {
+	return NodePoolAction{}
+}
+
+var providerNodepoolLabels = map[string]struct{}{
+	"eks.amazonaws.com/nodegroup":        {}, // AWS
+	"cloud.google.com/gke-nodepool":      {}, // GCP
+	"kubernetes.azure.com/agentpool":     {}, // "AKS"
+	"doks.digitalocean.com/node-pool-id": {}, // "DOKS"
+}
+
+// Discover the Node "pool" facet. This faceit is not provided natively by
+// Kubernetes, so it will be present only when using a managed
+// deployment/service provided by either of the vendors listed above.
+func (NodePoolAction) ComputeAttributes(obj any) (attributes, error) {
+	node, err := getNode(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := "none"
+	for label, value := range node.Labels {
+		if _, found := providerNodepoolLabels[label]; found {
+			pool = value
+			break
+		}
+	}
+	return attributes{NodePoolAttributeKey: pool}, nil
+}

--- a/components/processors/observek8sattributesprocessor/processor.go
+++ b/components/processors/observek8sattributesprocessor/processor.go
@@ -32,7 +32,7 @@ func newK8sEventsProcessor(logger *zap.Logger, cfg component.Config) *K8sEventsP
 			NewPodStatusAction(), NewPodContainersCountsAction(), NewPodReadinessAction(), NewPodConditionsAction(),
 		},
 		nodeActions: []K8sEventProcessorAction{
-			NewNodeStatusAction(), NewNodeRolesAction(),
+			NewNodeStatusAction(), NewNodeRolesAction(), NewNodePoolAction(),
 		},
 	}
 }

--- a/components/processors/observek8sattributesprocessor/processor_test.go
+++ b/components/processors/observek8sattributesprocessor/processor_test.go
@@ -141,6 +141,17 @@ func TestK8sEventsProcessor(t *testing.T) {
 				{"observe_transform.facets.conditions.TestCondition", "Unknown"},
 			},
 		},
+		{
+			name: "Node Pool",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/nodeObjectEventSimple.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.nodePool", "test-node-group"},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			kep := newK8sEventsProcessor(zap.NewNop(), &Config{})

--- a/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventSimple.json
+++ b/components/processors/observek8sattributesprocessor/testdata/nodeObjectEventSimple.json
@@ -22,7 +22,8 @@
             "minikube.k8s.io/updated_at": "2024_08_13T16_47_02_0700",
             "minikube.k8s.io/version": "v1.33.1",
             "node-role.kubernetes.io/control-plane": "",
-            "node.kubernetes.io/exclude-from-external-load-balancers": ""
+            "node.kubernetes.io/exclude-from-external-load-balancers": "",
+            "eks.amazonaws.com/nodegroup": "test-node-group"
         },
         "name": "minikube",
         "resourceVersion": "78297",


### PR DESCRIPTION
This facet is present only when the kubernetes deployment is a managed service by one of the following major providers:

- AWS EKS
- GCP EKE
- Azure AKS
- DigitalOcean DOKS