### PR TITLE
feat: implement custom processor actions for all facets that involve calculating the length of a pcommon.Slice

### DIFF
--- a/components/processors/observek8sattributesprocessor/configmapactions.go
+++ b/components/processors/observek8sattributesprocessor/configmapactions.go
@@ -8,7 +8,7 @@ const (
 	ConfigMapDataAttributeKey = "data"
 )
 
-// ---------------------------------- ConfigMap "endpoints" ----------------------------------
+// ---------------------------------- ConfigMap "data" ----------------------------------
 
 type ConfigMapDataAction struct{}
 
@@ -16,7 +16,7 @@ func NewConfigMapDataAction() ConfigMapDataAction {
 	return ConfigMapDataAction{}
 }
 
-// Generates the ConfigMap "endpoints" facet, which is a list of all individual endpoints, encoded as strings
+// Generates the ConfigMap "data" facet, calculated as the total number of entries in data and binaryData
 func (ConfigMapDataAction) ComputeAttributes(configMap corev1.ConfigMap) (attributes, error) {
 	return attributes{ConfigMapDataAttributeKey: len(configMap.Data) + len(configMap.BinaryData)}, nil
 }

--- a/components/processors/observek8sattributesprocessor/configmapactions.go
+++ b/components/processors/observek8sattributesprocessor/configmapactions.go
@@ -1,0 +1,22 @@
+package observek8sattributesprocessor
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	ConfigMapDataAttributeKey = "data"
+)
+
+// ---------------------------------- ConfigMap "endpoints" ----------------------------------
+
+type ConfigMapDataAction struct{}
+
+func NewConfigMapDataAction() ConfigMapDataAction {
+	return ConfigMapDataAction{}
+}
+
+// Generates the ConfigMap "endpoints" facet, which is a list of all individual endpoints, encoded as strings
+func (ConfigMapDataAction) ComputeAttributes(configMap corev1.ConfigMap) (attributes, error) {
+	return attributes{ConfigMapDataAttributeKey: len(configMap.Data) + len(configMap.BinaryData)}, nil
+}

--- a/components/processors/observek8sattributesprocessor/configmapactions_test.go
+++ b/components/processors/observek8sattributesprocessor/configmapactions_test.go
@@ -1,0 +1,17 @@
+package observek8sattributesprocessor
+
+import "testing"
+
+func TestConfigMapActions(t *testing.T) {
+	for _, testCase := range []k8sEventProcessorTest{
+		{
+			name:   "ConfigMap data",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/configMapEvent.json"),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.data", int64(1)},
+			},
+		},
+	} {
+		runTest(t, testCase)
+	}
+}

--- a/components/processors/observek8sattributesprocessor/daemonsetactions.go
+++ b/components/processors/observek8sattributesprocessor/daemonsetactions.go
@@ -6,19 +6,19 @@ import (
 )
 
 const (
-	DaemonsetSelectorAttributeKey = "selector"
+	DaemonSetSelectorAttributeKey = "selector"
 )
 
 type DaemonSetSelectorAction struct{}
 
-func NewDaemonsetSelectorAction() DaemonSetSelectorAction {
+func NewDaemonSetSelectorAction() DaemonSetSelectorAction {
 	return DaemonSetSelectorAction{}
 }
 
 // ---------------------------------- DaemonSet "selector" ----------------------------------
 
-// Generates the Daemonset "selector" facet.
+// Generates the DaemonSet "selector" facet.
 func (DaemonSetSelectorAction) ComputeAttributes(daemonset appsv1.DaemonSet) (attributes, error) {
-	selectorString := metav1.FormatLabelSelector(daemonset.Spec.Selector)
-	return attributes{DaemonsetSelectorAttributeKey: selectorString}, nil
+	selecotString := metav1.FormatLabelSelector(daemonset.Spec.Selector)
+	return attributes{DaemonSetSelectorAttributeKey: selecotString}, nil
 }

--- a/components/processors/observek8sattributesprocessor/deploymentactions.go
+++ b/components/processors/observek8sattributesprocessor/deploymentactions.go
@@ -1,0 +1,24 @@
+package observek8sattributesprocessor
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DeploymentSelectorAttributeKey = "selector"
+)
+
+type DeploymentSelectorAction struct{}
+
+func NewDeploymentSelectorAction() DeploymentSelectorAction {
+	return DeploymentSelectorAction{}
+}
+
+// ---------------------------------- Deployment "selector" ----------------------------------
+
+// Generates the Deployment "selector" facet.
+func (DeploymentSelectorAction) ComputeAttributes(deployment appsv1.Deployment) (attributes, error) {
+	selecotString := metav1.FormatLabelSelector(deployment.Spec.Selector)
+	return attributes{DeploymentSelectorAttributeKey: selecotString}, nil
+}

--- a/components/processors/observek8sattributesprocessor/deploymentactions_test.go
+++ b/components/processors/observek8sattributesprocessor/deploymentactions_test.go
@@ -1,0 +1,17 @@
+package observek8sattributesprocessor
+
+import "testing"
+
+func TestDeploymentActions(t *testing.T) {
+	for _, testCase := range []k8sEventProcessorTest{
+		{
+			name:   "Pretty print of a DaemonSet's selector",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/deploymentEvent.json"),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.selector", "app.kubernetes.io/instance=observe-agent,app.kubernetes.io/name=deployment-cluster-events,component=standalone-collector"},
+			},
+		},
+	} {
+		runTest(t, testCase)
+	}
+}

--- a/components/processors/observek8sattributesprocessor/ingressactions.go
+++ b/components/processors/observek8sattributesprocessor/ingressactions.go
@@ -26,6 +26,7 @@ func formatIngressRules(rules []netv1.IngressRule) string {
 }
 
 // ---------------------------------- Ingress "rules" ----------------------------------
+
 type IngressRulesAction struct{}
 
 func NewIngressRulesAction() IngressRulesAction {
@@ -38,6 +39,7 @@ func (IngressRulesAction) ComputeAttributes(ingress netv1.Ingress) (attributes, 
 }
 
 // ---------------------------------- Ingress "loadBalancer" ----------------------------------
+
 type IngressLoadBalancerAction struct{}
 
 func NewIngressLoadBalancerAction() IngressLoadBalancerAction {

--- a/components/processors/observek8sattributesprocessor/jobactions.go
+++ b/components/processors/observek8sattributesprocessor/jobactions.go
@@ -13,13 +13,14 @@ const (
 	JobDurationAttributeKey = "duration"
 )
 
+// ---------------------------------- Job "status" ----------------------------------
+
 type JobStatusAction struct{}
 
 func NewJobStatusAction() JobStatusAction {
 	return JobStatusAction{}
 }
 
-// ---------------------------------- Job "status" ----------------------------------
 func jobHasCondition(job batch.Job, conditionType batch.JobConditionType) bool {
 	for _, condition := range job.Status.Conditions {
 		if condition.Type == conditionType {
@@ -49,13 +50,13 @@ func (JobStatusAction) ComputeAttributes(job batch.Job) (attributes, error) {
 	return attributes{JobStatusAttributeKey: status}, nil
 }
 
+// ---------------------------------- Job "duration" ----------------------------------
+
 type JobDurationAction struct{}
 
 func NewJobDurationAction() JobDurationAction {
 	return JobDurationAction{}
 }
-
-// ---------------------------------- Job "duration" ----------------------------------
 
 // Implementation taken from https://github.com/kubernetes/apimachinery/blob/master/pkg/util/duration/duration.go
 // HumanDuration returns a succinct representation of the provided duration

--- a/components/processors/observek8sattributesprocessor/nodeactions.go
+++ b/components/processors/observek8sattributesprocessor/nodeactions.go
@@ -69,7 +69,7 @@ var providerNodepoolLabels = map[string]struct{}{
 	"doks.digitalocean.com/node-pool-id": {}, // "DOKS"
 }
 
-// Discover the Node "pool" facet. This faceit is not provided natively by
+// Discover the Node "pool" facet. This facet is not provided natively by
 // Kubernetes, so it will be present only when using a managed
 // deployment/service provided by either of the vendors listed above.
 func (NodePoolAction) ComputeAttributes(node v1.Node) (attributes, error) {
@@ -83,7 +83,7 @@ func (NodePoolAction) ComputeAttributes(node v1.Node) (attributes, error) {
 	return attributes{NodePoolAttributeKey: pool}, nil
 }
 
-// ---------------------------------- Node "pool" ----------------------------------
+// ---------------------------------- Node "roles" ----------------------------------
 
 type NodeRolesAction struct{}
 
@@ -91,7 +91,7 @@ func NewNodeRolesAction() NodeRolesAction {
 	return NodeRolesAction{}
 }
 
-// Generates the Node "status" facet. Assumes that objLog is a log from a Node event.
+// Generates the Node "roles" facet.
 func (NodeRolesAction) ComputeAttributes(node v1.Node) (attributes, error) {
 	// based on https://github.com/kubernetes/kubernetes/blob/dbc2b0a5c7acc349ea71a14e49913661eaf708d2/pkg/printers/internalversion/printers.go#L183https://github.com/kubernetes/kubernetes/blob/1e12d92a5179dbfeb455c79dbf9120c8536e5f9c/pkg/printers/internalversion/printers.go#L14875
 	roles := sets.NewString()

--- a/components/processors/observek8sattributesprocessor/persistentvolumeactions.go
+++ b/components/processors/observek8sattributesprocessor/persistentvolumeactions.go
@@ -8,6 +8,8 @@ const (
 	PersistentVolumeTypeAttributeKey = "volumeType"
 )
 
+// ---------------------------------- PersistentVolume "type" ----------------------------------
+
 type PersistentVolumeTypeAction struct{}
 
 func NewPersistentVolumeTypeAction() PersistentVolumeTypeAction {

--- a/components/processors/observek8sattributesprocessor/persistentvolumeclaimactions.go
+++ b/components/processors/observek8sattributesprocessor/persistentvolumeclaimactions.go
@@ -9,6 +9,8 @@ const (
 	PersistentVolumeClaimSelectorAttributeKey = "selector"
 )
 
+// ---------------------------------- PersistentVolumeClaim "selector" ----------------------------------
+
 type PersistentVolumeClaimSelectorAction struct{}
 
 func NewPersistentVolumeClaimSelectorAction() PersistentVolumeClaimSelectorAction {

--- a/components/processors/observek8sattributesprocessor/podactions.go
+++ b/components/processors/observek8sattributesprocessor/podactions.go
@@ -108,7 +108,7 @@ func (PodStatusAction) ComputeAttributes(pod v1.Pod) (attributes, error) {
 		reason = "Terminating"
 	}
 
-	return attributes{PodStatusAttributeKey: reason}, nil
+	return attributes{PodStatusAttributeKey: reason, "test": false}, nil
 }
 
 // ---------------------------------- various Pod "counts" ----------------------------------

--- a/components/processors/observek8sattributesprocessor/podactions.go
+++ b/components/processors/observek8sattributesprocessor/podactions.go
@@ -108,10 +108,10 @@ func (PodStatusAction) ComputeAttributes(pod v1.Pod) (attributes, error) {
 		reason = "Terminating"
 	}
 
-	return attributes{PodStatusAttributeKey: reason, "test": false}, nil
+	return attributes{PodStatusAttributeKey: reason}, nil
 }
 
-// ---------------------------------- various Pod "counts" ----------------------------------
+// ---------------------------------- various Pod counts ----------------------------------
 
 // This action computes various facets for Pod by aggregating "status" values
 // across all containers of a Pod.
@@ -229,7 +229,7 @@ func NewPodCronJobNameAction() PodCronJobNameAction {
 	return PodCronJobNameAction{}
 }
 
-// Name of the cronJob this Pod belongs to (only present if the owner is a CronJobName resource)
+// Name of the cronJob this Pod belongs to (only present if the owner is a CronJob resource)
 func (PodCronJobNameAction) ComputeAttributes(pod v1.Pod) (attributes, error) {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == OwnerKindCronJob {
@@ -247,7 +247,7 @@ func NewPodDaemonSetNameAction() PodDaemonSetNameAction {
 	return PodDaemonSetNameAction{}
 }
 
-// Name of the cronJob this Pod belongs to (only present if the owner is a DaemonSetName resource)
+// Name of the cronJob this Pod belongs to (only present if the owner is a DaemonSet resource)
 func (PodDaemonSetNameAction) ComputeAttributes(pod v1.Pod) (attributes, error) {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == OwnerKindDaemonSet {
@@ -265,7 +265,7 @@ func NewPodStatefulSetNameAction() PodStatefulSetNameAction {
 	return PodStatefulSetNameAction{}
 }
 
-// Name of the cronJob this Pod belongs to (only present if the owner is a StatefulSetName resource)
+// Name of the cronJob this Pod belongs to (only present if the owner is a StatefulSet resource)
 func (PodStatefulSetNameAction) ComputeAttributes(pod v1.Pod) (attributes, error) {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == OwnerKindStatefulSet {

--- a/components/processors/observek8sattributesprocessor/podactions_test.go
+++ b/components/processors/observek8sattributesprocessor/podactions_test.go
@@ -79,6 +79,18 @@ func TestPodActions(t *testing.T) {
 				{"observe_transform.facets.conditions.TestCondition", "Unknown"},
 			},
 		},
+		{
+			name: "Pod conditions",
+			inLogs: createResourceLogs(
+				logWithResource{
+					testBodyFilepath: "./testdata/podTestEvent.json",
+				},
+			),
+			expectedResults: []queryWithResult{
+				// Conditions must be a map with 5 elements
+				{"observe_transform.facets.conditions | length(@)", float64(5)},
+			},
+		},
 	} {
 		runTest(t, test)
 	}

--- a/components/processors/observek8sattributesprocessor/processor.go
+++ b/components/processors/observek8sattributesprocessor/processor.go
@@ -77,7 +77,7 @@ func newK8sEventsProcessor(logger *zap.Logger, cfg component.Config) *K8sEventsP
 			NewServiceLBIngressAction(), NewServiceSelectorAction(), NewServicePortsAction(),
 		},
 		serviceAccountActions: []serviceAccountAction{
-			NewServiceAccountSecretsNamesAction(),
+			NewServiceAccountSecretsNamesAction(), NewServiceAccountSecretsAction(), NewServiceAccountImagePullSecretsAction(),
 		},
 		configMapActions: []configMapAction{
 			NewConfigMapDataAction(),

--- a/components/processors/observek8sattributesprocessor/serviceaccountactions.go
+++ b/components/processors/observek8sattributesprocessor/serviceaccountactions.go
@@ -6,10 +6,13 @@ import (
 )
 
 const (
-	ServiceAccountSecretsNamesAttributeKey = "secretsNames"
+	ServiceAccountSecretsNamesAttributeKey     = "secretsNames"
+	ServiceAccountSecretsAttributeKey          = "secrets"
+	ServiceAccountImagePullSecretsAttributeKey = "imagePullSecrets"
 )
 
 // ---------------------------------- ServiceAccount "secretsNames" ----------------------------------
+
 type ServiceAccountSecretsNamesAction struct{}
 
 func NewServiceAccountSecretsNamesAction() ServiceAccountSecretsNamesAction {
@@ -24,4 +27,30 @@ func (ServiceAccountSecretsNamesAction) ComputeAttributes(serviceAccount corev1.
 	}
 
 	return attributes{ServiceAccountSecretsNamesAttributeKey: result.List()}, nil
+}
+
+// ---------------------------------- ServiceAccount "secrets" ----------------------------------
+
+type ServiceAccountSecretsAction struct{}
+
+func NewServiceAccountSecretsAction() ServiceAccountSecretsAction {
+	return ServiceAccountSecretsAction{}
+}
+
+// Generates the ServiceAccount "secrets" facet.
+func (ServiceAccountSecretsAction) ComputeAttributes(serviceAccount corev1.ServiceAccount) (attributes, error) {
+	return attributes{ServiceAccountSecretsAttributeKey: len(serviceAccount.Secrets)}, nil
+}
+
+// ---------------------------------- ServiceAccount "imagePullSecrets" ----------------------------------
+
+type ServiceAccountImagePullSecretsAction struct{}
+
+func NewServiceAccountImagePullSecretsAction() ServiceAccountImagePullSecretsAction {
+	return ServiceAccountImagePullSecretsAction{}
+}
+
+// Generates the ServiceAccount "ImagePullSecrets" facet.
+func (ServiceAccountImagePullSecretsAction) ComputeAttributes(serviceAccount corev1.ServiceAccount) (attributes, error) {
+	return attributes{ServiceAccountImagePullSecretsAttributeKey: len(serviceAccount.ImagePullSecrets)}, nil
 }

--- a/components/processors/observek8sattributesprocessor/serviceaccountactions_test.go
+++ b/components/processors/observek8sattributesprocessor/serviceaccountactions_test.go
@@ -5,10 +5,24 @@ import "testing"
 func TestServiceAccountActions(t *testing.T) {
 	for _, testCase := range []k8sEventProcessorTest{
 		{
-			name:   "Service account secrets",
+			name:   "Service account secrets' names",
 			inLogs: resourceLogsFromSingleJsonEvent("./testdata/serviceAccountEvent.json"),
 			expectedResults: []queryWithResult{
 				{"observe_transform.facets.secretsNames", []any{"example-another-secret", "example-serviceaccount-token-abcdef"}},
+			},
+		},
+		{
+			name:   "Service account secrets",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/serviceAccountEvent.json"),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.secrets", int64(2)},
+			},
+		},
+		{
+			name:   "Service account imagePull secrets",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/serviceAccountEvent.json"),
+			expectedResults: []queryWithResult{
+				{"observe_transform.facets.imagePullSecrets", int64(0)},
 			},
 		},
 	} {

--- a/components/processors/observek8sattributesprocessor/serviceactions.go
+++ b/components/processors/observek8sattributesprocessor/serviceactions.go
@@ -76,7 +76,7 @@ func NewServiceSelectorAction() ServiceSelectorAction {
 // Generates the Service "selector" facet.
 func (ServiceSelectorAction) ComputeAttributes(service corev1.Service) (attributes, error) {
 	selectorString := FormatLabels(service.Spec.Selector)
-	return attributes{DaemonsetSelectorAttributeKey: selectorString}, nil
+	return attributes{DaemonSetSelectorAttributeKey: selectorString}, nil
 
 }
 

--- a/components/processors/observek8sattributesprocessor/statefulsetactions.go
+++ b/components/processors/observek8sattributesprocessor/statefulsetactions.go
@@ -9,13 +9,13 @@ const (
 	StatefulsetSelectorAttributeKey = "selector"
 )
 
+// ---------------------------------- StatefulSet "selector" ----------------------------------
+
 type StatefulSetSelectorAction struct{}
 
 func NewStatefulsetSelectorAction() StatefulSetSelectorAction {
 	return StatefulSetSelectorAction{}
 }
-
-// ---------------------------------- StatefulSet "selector" ----------------------------------
 
 // Generates the Statefulset "selector" facet.
 func (StatefulSetSelectorAction) ComputeAttributes(statefulSet appsv1.StatefulSet) (attributes, error) {

--- a/components/processors/observek8sattributesprocessor/testdata/configMapEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/configMapEvent.json
@@ -1,0 +1,29 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "ClusterConfiguration": "apiServer:\n  certSANs:\n  - 127.0.0.1\n  - localhost\n  - 192.168.49.2\n  extraArgs:\n    enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota\n  timeoutForControlPlane: 4m0s\napiVersion: kubeadm.k8s.io/v1beta3\ncertificatesDir: /var/lib/minikube/certs\nclusterName: mk\ncontrolPlaneEndpoint: control-plane.minikube.internal:8443\ncontrollerManager:\n  extraArgs:\n    allocate-node-cidrs: \"true\"\n    leader-elect: \"false\"\ndns: {}\netcd:\n  local:\n    dataDir: /var/lib/minikube/etcd\n    extraArgs:\n      proxy-refresh-interval: \"70000\"\nimageRepository: registry.k8s.io\nkind: ClusterConfiguration\nkubernetesVersion: v1.30.0\nnetworking:\n  dnsDomain: cluster.local\n  podSubnet: 10.244.0.0/16\n  serviceSubnet: 10.96.0.0/12\nscheduler:\n  extraArgs:\n    leader-elect: \"false\"\n"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2024-08-13T14:47:00Z",
+        "managedFields": [
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:data": {
+                        ".": {},
+                        "f:ClusterConfiguration": {}
+                    }
+                },
+                "manager": "kubeadm",
+                "operation": "Update",
+                "time": "2024-08-13T14:47:00Z"
+            }
+        ],
+        "name": "kubeadm-config",
+        "namespace": "kube-system",
+        "resourceVersion": "203",
+        "uid": "80592d9c-0d75-4539-84a3-cde3df3d7fed"
+    }
+}

--- a/components/processors/observek8sattributesprocessor/testdata/deploymentEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/deploymentEvent.json
@@ -1,0 +1,518 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "deployment.kubernetes.io/revision": "1",
+      "meta.helm.sh/release-name": "observe-agent",
+      "meta.helm.sh/release-namespace": "k8sexplorer"
+    },
+    "creationTimestamp": "2024-09-05T16:46:06Z",
+    "generation": 1,
+    "labels": {
+      "app.kubernetes.io/instance": "observe-agent",
+      "app.kubernetes.io/managed-by": "Helm",
+      "app.kubernetes.io/name": "deployment-cluster-events",
+      "app.kubernetes.io/version": "0.106.1",
+      "helm.sh/chart": "deployment-cluster-events-0.101.1"
+    },
+    "managedFields": [
+      {
+        "apiVersion": "apps/v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": {
+              ".": {},
+              "f:meta.helm.sh/release-name": {},
+              "f:meta.helm.sh/release-namespace": {}
+            },
+            "f:labels": {
+              ".": {},
+              "f:app.kubernetes.io/instance": {},
+              "f:app.kubernetes.io/managed-by": {},
+              "f:app.kubernetes.io/name": {},
+              "f:app.kubernetes.io/version": {},
+              "f:helm.sh/chart": {}
+            }
+          },
+          "f:spec": {
+            "f:progressDeadlineSeconds": {},
+            "f:replicas": {},
+            "f:revisionHistoryLimit": {},
+            "f:selector": {},
+            "f:strategy": {
+              "f:rollingUpdate": {
+                ".": {},
+                "f:maxSurge": {},
+                "f:maxUnavailable": {}
+              },
+              "f:type": {}
+            },
+            "f:template": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:checksum/config": {},
+                  "f:observe_monitor_path": {},
+                  "f:observe_monitor_port": {},
+                  "f:observe_monitor_purpose": {},
+                  "f:observe_monitor_scrape": {}
+                },
+                "f:labels": {
+                  ".": {},
+                  "f:app.kubernetes.io/instance": {},
+                  "f:app.kubernetes.io/name": {},
+                  "f:component": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"deployment-cluster-events\"}": {
+                    ".": {},
+                    "f:args": {},
+                    "f:command": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"ENTITY_TOKEN\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:secretKeyRef": {} }
+                      },
+                      "k:{\"name\":\"MY_POD_IP\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:fieldRef": {} }
+                      },
+                      "k:{\"name\":\"OBSERVE_CLUSTER_NAME\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:configMapKeyRef": {} }
+                      },
+                      "k:{\"name\":\"OBSERVE_CLUSTER_UID\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:configMapKeyRef": {} }
+                      },
+                      "k:{\"name\":\"TOKEN\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:secretKeyRef": {} }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:livenessProbe": {
+                      ".": {},
+                      "f:failureThreshold": {},
+                      "f:httpGet": {
+                        ".": {},
+                        "f:path": {},
+                        "f:port": {},
+                        "f:scheme": {}
+                      },
+                      "f:initialDelaySeconds": {},
+                      "f:periodSeconds": {},
+                      "f:successThreshold": {},
+                      "f:timeoutSeconds": {}
+                    },
+                    "f:name": {},
+                    "f:ports": {
+                      ".": {},
+                      "k:{\"containerPort\":14250,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":14268,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":4317,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":4318,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":6831,\"protocol\":\"UDP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":8888,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      },
+                      "k:{\"containerPort\":9411,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      }
+                    },
+                    "f:readinessProbe": {
+                      ".": {},
+                      "f:failureThreshold": {},
+                      "f:httpGet": {
+                        ".": {},
+                        "f:path": {},
+                        "f:port": {},
+                        "f:scheme": {}
+                      },
+                      "f:initialDelaySeconds": {},
+                      "f:periodSeconds": {},
+                      "f:successThreshold": {},
+                      "f:timeoutSeconds": {}
+                    },
+                    "f:resources": {
+                      ".": {},
+                      "f:requests": { ".": {}, "f:cpu": {}, "f:memory": {} }
+                    },
+                    "f:securityContext": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/conf\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      },
+                      "k:{\"mountPath\":\"/observe-agent-conf\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:initContainers": {
+                  ".": {},
+                  "k:{\"name\":\"kube-cluster-info\"}": {
+                    ".": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"NAMESPACE\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": { ".": {}, "f:fieldRef": {} }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:serviceAccount": {},
+                "f:serviceAccountName": {},
+                "f:terminationGracePeriodSeconds": {},
+                "f:volumes": {
+                  ".": {},
+                  "k:{\"name\":\"deployment-cluster-events-configmap\"}": {
+                    ".": {},
+                    "f:configMap": {
+                      ".": {},
+                      "f:defaultMode": {},
+                      "f:items": {},
+                      "f:name": {}
+                    },
+                    "f:name": {}
+                  },
+                  "k:{\"name\":\"observe-agent-deployment-config\"}": {
+                    ".": {},
+                    "f:configMap": {
+                      ".": {},
+                      "f:defaultMode": {},
+                      "f:items": {},
+                      "f:name": {}
+                    },
+                    "f:name": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "manager": "helm",
+        "operation": "Update",
+        "time": "2024-09-05T16:46:06Z"
+      },
+      {
+        "apiVersion": "apps/v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": { "f:deployment.kubernetes.io/revision": {} }
+          },
+          "f:status": {
+            "f:conditions": {
+              ".": {},
+              "k:{\"type\":\"Available\"}": {
+                ".": {},
+                "f:lastTransitionTime": {},
+                "f:lastUpdateTime": {},
+                "f:message": {},
+                "f:reason": {},
+                "f:status": {},
+                "f:type": {}
+              },
+              "k:{\"type\":\"Progressing\"}": {
+                ".": {},
+                "f:lastTransitionTime": {},
+                "f:lastUpdateTime": {},
+                "f:message": {},
+                "f:reason": {},
+                "f:status": {},
+                "f:type": {}
+              }
+            },
+            "f:observedGeneration": {},
+            "f:replicas": {},
+            "f:unavailableReplicas": {},
+            "f:updatedReplicas": {}
+          }
+        },
+        "manager": "kube-controller-manager",
+        "operation": "Update",
+        "subresource": "status",
+        "time": "2024-09-05T16:46:06Z"
+      }
+    ],
+    "name": "observe-agent-deployment-cluster-events",
+    "namespace": "k8sexplorer",
+    "resourceVersion": "721374",
+    "uid": "4b1f5c98-3dfd-4b02-88a3-61fdef1d4d15"
+  },
+  "spec": {
+    "progressDeadlineSeconds": 600,
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app.kubernetes.io/instance": "observe-agent",
+        "app.kubernetes.io/name": "deployment-cluster-events",
+        "component": "standalone-collector"
+      }
+    },
+    "strategy": {
+      "rollingUpdate": { "maxSurge": "25%", "maxUnavailable": "25%" },
+      "type": "RollingUpdate"
+    },
+    "template": {
+      "metadata": {
+        "annotations": {
+          "checksum/config": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+          "observe_monitor_path": "/metrics",
+          "observe_monitor_port": "8888",
+          "observe_monitor_purpose": "observecollection",
+          "observe_monitor_scrape": "true"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "app.kubernetes.io/instance": "observe-agent",
+          "app.kubernetes.io/name": "deployment-cluster-events",
+          "component": "standalone-collector"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": [
+              "--config=/conf/relay.yaml",
+              "start",
+              "--config=/observe-agent-conf/observe-agent.yaml",
+              "--otel-config=/conf/relay.yaml"
+            ],
+            "command": ["/observe-agent"],
+            "env": [
+              {
+                "name": "MY_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "OBSERVE_CLUSTER_NAME",
+                "valueFrom": {
+                  "configMapKeyRef": { "key": "name", "name": "cluster-name" }
+                }
+              },
+              {
+                "name": "OBSERVE_CLUSTER_UID",
+                "valueFrom": {
+                  "configMapKeyRef": { "key": "id", "name": "cluster-info" }
+                }
+              },
+              {
+                "name": "TOKEN",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "key": "OBSERVE_TOKEN",
+                    "name": "agent-credentials",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "ENTITY_TOKEN",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "key": "ENTITY_TOKEN",
+                    "name": "agent-credentials",
+                    "optional": true
+                  }
+                }
+              }
+            ],
+            "image": "observe-agent:test-k8s",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "failureThreshold": 3,
+              "httpGet": { "path": "/status", "port": 13133, "scheme": "HTTP" },
+              "initialDelaySeconds": 30,
+              "periodSeconds": 5,
+              "successThreshold": 1,
+              "timeoutSeconds": 1
+            },
+            "name": "deployment-cluster-events",
+            "ports": [
+              {
+                "containerPort": 6831,
+                "name": "jaeger-compact",
+                "protocol": "UDP"
+              },
+              {
+                "containerPort": 14250,
+                "name": "jaeger-grpc",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 14268,
+                "name": "jaeger-thrift",
+                "protocol": "TCP"
+              },
+              { "containerPort": 8888, "name": "metrics", "protocol": "TCP" },
+              { "containerPort": 4317, "name": "otlp", "protocol": "TCP" },
+              { "containerPort": 4318, "name": "otlp-http", "protocol": "TCP" },
+              { "containerPort": 9411, "name": "zipkin", "protocol": "TCP" }
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": { "path": "/status", "port": 13133, "scheme": "HTTP" },
+              "initialDelaySeconds": 30,
+              "periodSeconds": 5,
+              "successThreshold": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": { "requests": { "cpu": "250m", "memory": "256Mi" } },
+            "securityContext": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/conf",
+                "name": "deployment-cluster-events-configmap"
+              },
+              {
+                "mountPath": "/observe-agent-conf",
+                "name": "observe-agent-deployment-config"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "initContainers": [
+          {
+            "env": [
+              {
+                "name": "NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "image": "observeinc/kube-cluster-info:v0.11.1",
+            "imagePullPolicy": "Always",
+            "name": "kube-cluster-info",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "observe-agent-service-account",
+        "serviceAccountName": "observe-agent-service-account",
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "items": [{ "key": "relay", "path": "relay.yaml" }],
+              "name": "deployment-cluster-events"
+            },
+            "name": "deployment-cluster-events-configmap"
+          },
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "items": [{ "key": "relay", "path": "observe-agent.yaml" }],
+              "name": "observe-agent"
+            },
+            "name": "observe-agent-deployment-config"
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-09-05T16:46:06Z",
+        "lastUpdateTime": "2024-09-05T16:46:06Z",
+        "message": "Deployment does not have minimum availability.",
+        "reason": "MinimumReplicasUnavailable",
+        "status": "False",
+        "type": "Available"
+      },
+      {
+        "lastTransitionTime": "2024-09-05T16:46:06Z",
+        "lastUpdateTime": "2024-09-05T16:46:06Z",
+        "message": "ReplicaSet \"observe-agent-deployment-cluster-events-68b9b7d8ff\" is progressing.",
+        "reason": "ReplicaSetUpdated",
+        "status": "True",
+        "type": "Progressing"
+      }
+    ],
+    "observedGeneration": 1,
+    "replicas": 1,
+    "unavailableReplicas": 1,
+    "updatedReplicas": 1
+  }
+}

--- a/components/processors/observek8sattributesprocessor/testdata/podTestEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/podTestEvent.json
@@ -1,0 +1,690 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "checksum/config": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+            "cni.projectcalico.org/containerID": "072732b05a33263bd15d9fb98d1aae5f39ef02b25ec9e2e47cf8435c11c8cbdd",
+            "cni.projectcalico.org/podIP": "10.244.120.125/32",
+            "cni.projectcalico.org/podIPs": "10.244.120.125/32",
+            "observe_monitor_path": "/metrics",
+            "observe_monitor_port": "8888",
+            "observe_monitor_purpose": "observecollection",
+            "observe_monitor_scrape": "true"
+        },
+        "creationTimestamp": "2024-09-04T19:53:27Z",
+        "generateName": "observe-agent-deployment-cluster-metrics-86557fdf55-",
+        "labels": {
+            "app.kubernetes.io/instance": "observe-agent",
+            "app.kubernetes.io/name": "deployment-cluster-metrics",
+            "component": "standalone-collector",
+            "pod-template-hash": "86557fdf55"
+        },
+        "managedFields": [
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:checksum/config": {},
+                            "f:observe_monitor_path": {},
+                            "f:observe_monitor_port": {},
+                            "f:observe_monitor_purpose": {},
+                            "f:observe_monitor_scrape": {}
+                        },
+                        "f:generateName": {},
+                        "f:labels": {
+                            ".": {},
+                            "f:app.kubernetes.io/instance": {},
+                            "f:app.kubernetes.io/name": {},
+                            "f:component": {},
+                            "f:pod-template-hash": {}
+                        },
+                        "f:ownerReferences": {
+                            ".": {},
+                            "k:{\"uid\":\"7c6da50b-6ef8-4dcc-8451-d30985bc3e6b\"}": {}
+                        }
+                    },
+                    "f:spec": {
+                        "f:containers": {
+                            "k:{\"name\":\"deployment-cluster-metrics\"}": {
+                                ".": {},
+                                "f:args": {},
+                                "f:command": {},
+                                "f:env": {
+                                    ".": {},
+                                    "k:{\"name\":\"MY_POD_IP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:valueFrom": {
+                                            ".": {},
+                                            "f:fieldRef": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"OBSERVE_CLUSTER_NAME\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:valueFrom": {
+                                            ".": {},
+                                            "f:configMapKeyRef": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"OBSERVE_CLUSTER_UID\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:valueFrom": {
+                                            ".": {},
+                                            "f:configMapKeyRef": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"TOKEN\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:valueFrom": {
+                                            ".": {},
+                                            "f:secretKeyRef": {}
+                                        }
+                                    }
+                                },
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:livenessProbe": {
+                                    ".": {},
+                                    "f:failureThreshold": {},
+                                    "f:httpGet": {
+                                        ".": {},
+                                        "f:path": {},
+                                        "f:port": {},
+                                        "f:scheme": {}
+                                    },
+                                    "f:initialDelaySeconds": {},
+                                    "f:periodSeconds": {},
+                                    "f:successThreshold": {},
+                                    "f:timeoutSeconds": {}
+                                },
+                                "f:name": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"containerPort\":14250,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":14268,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":4317,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":4318,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":6831,\"protocol\":\"UDP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":8888,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    },
+                                    "k:{\"containerPort\":9411,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:name": {},
+                                        "f:protocol": {}
+                                    }
+                                },
+                                "f:readinessProbe": {
+                                    ".": {},
+                                    "f:failureThreshold": {},
+                                    "f:httpGet": {
+                                        ".": {},
+                                        "f:path": {},
+                                        "f:port": {},
+                                        "f:scheme": {}
+                                    },
+                                    "f:initialDelaySeconds": {},
+                                    "f:periodSeconds": {},
+                                    "f:successThreshold": {},
+                                    "f:timeoutSeconds": {}
+                                },
+                                "f:resources": {
+                                    ".": {},
+                                    "f:requests": {
+                                        ".": {},
+                                        "f:cpu": {},
+                                        "f:memory": {}
+                                    }
+                                },
+                                "f:securityContext": {},
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {},
+                                "f:volumeMounts": {
+                                    ".": {},
+                                    "k:{\"mountPath\":\"/conf\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"mountPath\":\"/observe-agent-conf\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    }
+                                }
+                            }
+                        },
+                        "f:dnsPolicy": {},
+                        "f:enableServiceLinks": {},
+                        "f:initContainers": {
+                            ".": {},
+                            "k:{\"name\":\"kube-cluster-info\"}": {
+                                ".": {},
+                                "f:env": {
+                                    ".": {},
+                                    "k:{\"name\":\"NAMESPACE\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:valueFrom": {
+                                            ".": {},
+                                            "f:fieldRef": {}
+                                        }
+                                    }
+                                },
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:name": {},
+                                "f:resources": {},
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {}
+                            }
+                        },
+                        "f:restartPolicy": {},
+                        "f:schedulerName": {},
+                        "f:securityContext": {},
+                        "f:serviceAccount": {},
+                        "f:serviceAccountName": {},
+                        "f:terminationGracePeriodSeconds": {},
+                        "f:volumes": {
+                            ".": {},
+                            "k:{\"name\":\"deployment-cluster-metrics-configmap\"}": {
+                                ".": {},
+                                "f:configMap": {
+                                    ".": {},
+                                    "f:defaultMode": {},
+                                    "f:items": {},
+                                    "f:name": {}
+                                },
+                                "f:name": {}
+                            },
+                            "k:{\"name\":\"observe-agent-deployment-config\"}": {
+                                ".": {},
+                                "f:configMap": {
+                                    ".": {},
+                                    "f:defaultMode": {},
+                                    "f:items": {},
+                                    "f:name": {}
+                                },
+                                "f:name": {}
+                            }
+                        }
+                    }
+                },
+                "manager": "kube-controller-manager",
+                "operation": "Update",
+                "time": "2024-09-04T19:53:27Z"
+            },
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            "f:cni.projectcalico.org/containerID": {},
+                            "f:cni.projectcalico.org/podIP": {},
+                            "f:cni.projectcalico.org/podIPs": {}
+                        }
+                    }
+                },
+                "manager": "calico",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2024-09-04T19:53:28Z"
+            },
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:status": {
+                        "f:conditions": {
+                            "k:{\"type\":\"ContainersReady\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            },
+                            "k:{\"type\":\"Initialized\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            },
+                            "k:{\"type\":\"PodReadyToStartContainers\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            },
+                            "k:{\"type\":\"Ready\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            }
+                        },
+                        "f:containerStatuses": {},
+                        "f:hostIP": {},
+                        "f:hostIPs": {},
+                        "f:initContainerStatuses": {},
+                        "f:phase": {},
+                        "f:podIP": {},
+                        "f:podIPs": {
+                            ".": {},
+                            "k:{\"ip\":\"10.244.120.125\"}": {
+                                ".": {},
+                                "f:ip": {}
+                            }
+                        },
+                        "f:startTime": {}
+                    }
+                },
+                "manager": "kubelet",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2024-09-04T19:54:03Z"
+            }
+        ],
+        "name": "observe-agent-deployment-cluster-metrics-86557fdf55-7dgch",
+        "namespace": "k8sexplorer",
+        "ownerReferences": [
+            {
+                "apiVersion": "apps/v1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "ReplicaSet",
+                "name": "observe-agent-deployment-cluster-metrics-86557fdf55",
+                "uid": "7c6da50b-6ef8-4dcc-8451-d30985bc3e6b"
+            }
+        ],
+        "resourceVersion": "624523",
+        "uid": "e210ef73-d53b-4ec3-8bec-5d9906e8d470"
+    },
+    "spec": {
+        "containers": [
+            {
+                "args": [
+                    "--config=/conf/relay.yaml",
+                    "start",
+                    "--config=/observe-agent-conf/observe-agent.yaml",
+                    "--otel-config=/conf/relay.yaml"
+                ],
+                "command": [
+                    "/observe-agent"
+                ],
+                "env": [
+                    {
+                        "name": "MY_POD_IP",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "status.podIP"
+                            }
+                        }
+                    },
+                    {
+                        "name": "OBSERVE_CLUSTER_NAME",
+                        "valueFrom": {
+                            "configMapKeyRef": {
+                                "key": "name",
+                                "name": "cluster-name"
+                            }
+                        }
+                    },
+                    {
+                        "name": "OBSERVE_CLUSTER_UID",
+                        "valueFrom": {
+                            "configMapKeyRef": {
+                                "key": "id",
+                                "name": "cluster-info"
+                            }
+                        }
+                    },
+                    {
+                        "name": "TOKEN",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "key": "OBSERVE_TOKEN",
+                                "name": "agent-credentials",
+                                "optional": true
+                            }
+                        }
+                    }
+                ],
+                "image": "observeinc/observe-agent:1.0.0",
+                "imagePullPolicy": "IfNotPresent",
+                "livenessProbe": {
+                    "failureThreshold": 3,
+                    "httpGet": {
+                        "path": "/status",
+                        "port": 13133,
+                        "scheme": "HTTP"
+                    },
+                    "initialDelaySeconds": 30,
+                    "periodSeconds": 5,
+                    "successThreshold": 1,
+                    "timeoutSeconds": 1
+                },
+                "name": "deployment-cluster-metrics",
+                "ports": [
+                    {
+                        "containerPort": 6831,
+                        "name": "jaeger-compact",
+                        "protocol": "UDP"
+                    },
+                    {
+                        "containerPort": 14250,
+                        "name": "jaeger-grpc",
+                        "protocol": "TCP"
+                    },
+                    {
+                        "containerPort": 14268,
+                        "name": "jaeger-thrift",
+                        "protocol": "TCP"
+                    },
+                    {
+                        "containerPort": 8888,
+                        "name": "metrics",
+                        "protocol": "TCP"
+                    },
+                    {
+                        "containerPort": 4317,
+                        "name": "otlp",
+                        "protocol": "TCP"
+                    },
+                    {
+                        "containerPort": 4318,
+                        "name": "otlp-http",
+                        "protocol": "TCP"
+                    },
+                    {
+                        "containerPort": 9411,
+                        "name": "zipkin",
+                        "protocol": "TCP"
+                    }
+                ],
+                "readinessProbe": {
+                    "failureThreshold": 3,
+                    "httpGet": {
+                        "path": "/status",
+                        "port": 13133,
+                        "scheme": "HTTP"
+                    },
+                    "initialDelaySeconds": 30,
+                    "periodSeconds": 5,
+                    "successThreshold": 1,
+                    "timeoutSeconds": 1
+                },
+                "resources": {
+                    "requests": {
+                        "cpu": "250m",
+                        "memory": "256Mi"
+                    }
+                },
+                "securityContext": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/conf",
+                        "name": "deployment-cluster-metrics-configmap"
+                    },
+                    {
+                        "mountPath": "/observe-agent-conf",
+                        "name": "observe-agent-deployment-config"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "kube-api-access-dprg9",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "initContainers": [
+            {
+                "env": [
+                    {
+                        "name": "NAMESPACE",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "metadata.namespace"
+                            }
+                        }
+                    }
+                ],
+                "image": "observeinc/kube-cluster-info:v0.11.1",
+                "imagePullPolicy": "Always",
+                "name": "kube-cluster-info",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "kube-api-access-dprg9",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "nodeName": "minikube",
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "observe-agent-service-account",
+        "serviceAccountName": "observe-agent-service-account",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            }
+        ],
+        "volumes": [
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "items": [
+                        {
+                            "key": "relay",
+                            "path": "relay.yaml"
+                        }
+                    ],
+                    "name": "deployment-cluster-metrics"
+                },
+                "name": "deployment-cluster-metrics-configmap"
+            },
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "items": [
+                        {
+                            "key": "relay",
+                            "path": "observe-agent.yaml"
+                        }
+                    ],
+                    "name": "observe-agent"
+                },
+                "name": "observe-agent-deployment-config"
+            },
+            {
+                "name": "kube-api-access-dprg9",
+                "projected": {
+                    "defaultMode": 420,
+                    "sources": [
+                        {
+                            "serviceAccountToken": {
+                                "expirationSeconds": 3607,
+                                "path": "token"
+                            }
+                        },
+                        {
+                            "configMap": {
+                                "items": [
+                                    {
+                                        "key": "ca.crt",
+                                        "path": "ca.crt"
+                                    }
+                                ],
+                                "name": "kube-root-ca.crt"
+                            }
+                        },
+                        {
+                            "downwardAPI": {
+                                "items": [
+                                    {
+                                        "fieldRef": {
+                                            "apiVersion": "v1",
+                                            "fieldPath": "metadata.namespace"
+                                        },
+                                        "path": "namespace"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-09-04T19:53:31Z",
+                "status": "True",
+                "type": "PodReadyToStartContainers"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-09-04T19:53:31Z",
+                "status": "True",
+                "type": "Initialized"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-09-04T19:54:03Z",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-09-04T19:54:03Z",
+                "status": "True",
+                "type": "ContainersReady"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-09-04T19:53:27Z",
+                "status": "True",
+                "type": "PodScheduled"
+            }
+        ],
+        "containerStatuses": [
+            {
+                "containerID": "docker://35e8ccd3c8e7ea300cf1641d8cd73367142ed04842d75bf1066e9d4836a5d4c5",
+                "image": "observeinc/observe-agent:1.0.0",
+                "imageID": "docker-pullable://observeinc/observe-agent@sha256:a75c3ac8f55c0f033a09bf44c1e99b3939d5fe364468d7c3cb54cf21e61d1f4b",
+                "lastState": {},
+                "name": "deployment-cluster-metrics",
+                "ready": true,
+                "restartCount": 0,
+                "started": true,
+                "state": {
+                    "running": {
+                        "startedAt": "2024-09-04T19:53:31Z"
+                    }
+                }
+            }
+        ],
+        "hostIP": "192.168.49.2",
+        "hostIPs": [
+            {
+                "ip": "192.168.49.2"
+            }
+        ],
+        "initContainerStatuses": [
+            {
+                "containerID": "docker://a4217435cd1cee279da7c40a174ec394e67ffa491772d419544c66fc0a55c934",
+                "image": "observeinc/kube-cluster-info:v0.11.1",
+                "imageID": "docker-pullable://observeinc/kube-cluster-info@sha256:c574e14860df6af618677311eaa8dba6700c4ca0a04ddca52d3a1bf2b9c4fc85",
+                "lastState": {},
+                "name": "kube-cluster-info",
+                "ready": true,
+                "restartCount": 0,
+                "started": false,
+                "state": {
+                    "terminated": {
+                        "containerID": "docker://a4217435cd1cee279da7c40a174ec394e67ffa491772d419544c66fc0a55c934",
+                        "exitCode": 0,
+                        "finishedAt": "2024-09-04T19:53:30Z",
+                        "reason": "Completed",
+                        "startedAt": "2024-09-04T19:53:30Z"
+                    }
+                }
+            }
+        ],
+        "phase": "Running",
+        "podIP": "10.244.120.125",
+        "podIPs": [
+            {
+                "ip": "10.244.120.125"
+            }
+        ],
+        "qosClass": "Burstable",
+        "startTime": "2024-09-04T19:53:27Z"
+    }
+}

--- a/components/processors/observek8sattributesprocessor/types.go
+++ b/components/processors/observek8sattributesprocessor/types.go
@@ -72,6 +72,9 @@ type serviceAction interface {
 type serviceAccountAction interface {
 	ComputeAttributes(corev1.ServiceAccount) (attributes, error)
 }
+type configMapAction interface {
+	ComputeAttributes(corev1.ConfigMap) (attributes, error)
+}
 
 type jobAction interface {
 	ComputeAttributes(batchv1.Job) (attributes, error)
@@ -98,9 +101,6 @@ type ingressAction interface {
 }
 type endpointsAction interface {
 	ComputeAttributes(corev1.Endpoints) (attributes, error)
-}
-type configMapAction interface {
-	ComputeAttributes(corev1.ConfigMap) (attributes, error)
 }
 
 func (proc *K8sEventsProcessor) RunActions(obj metav1.Object) (attributes, error) {
@@ -261,6 +261,18 @@ func (m *K8sEventsProcessor) runServiceActions(service corev1.Service) (attribut
 	return res, nil
 }
 
+func (m *K8sEventsProcessor) runConfigMapActions(configMap corev1.ConfigMap) (attributes, error) {
+	res := attributes{}
+	for _, action := range m.configMapActions {
+		atts, err := action.ComputeAttributes(configMap)
+		if err != nil {
+			return res, err
+		}
+		res.addAttributes(atts)
+	}
+	return res, nil
+}
+
 func (m *K8sEventsProcessor) runServiceAccountActions(serviceAccount corev1.ServiceAccount) (attributes, error) {
 	res := attributes{}
 	for _, action := range m.serviceAccountActions {
@@ -277,18 +289,6 @@ func (m *K8sEventsProcessor) runEndpointsActions(endpoints corev1.Endpoints) (at
 	res := attributes{}
 	for _, action := range m.endpointsActions {
 		atts, err := action.ComputeAttributes(endpoints)
-		if err != nil {
-			return res, err
-		}
-		res.addAttributes(atts)
-	}
-	return res, nil
-}
-
-func (m *K8sEventsProcessor) runConfigMapActions(configMap corev1.ConfigMap) (attributes, error) {
-	res := attributes{}
-	for _, action := range m.configMapActions {
-		atts, err := action.ComputeAttributes(configMap)
 		if err != nil {
 			return res, err
 		}

--- a/components/processors/observek8sattributesprocessor/types.go
+++ b/components/processors/observek8sattributesprocessor/types.go
@@ -90,6 +90,9 @@ type daemonSetAction interface {
 	ComputeAttributes(appsv1.DaemonSet) (attributes, error)
 }
 
+type deploymentAction interface {
+	ComputeAttributes(appsv1.Deployment) (attributes, error)
+}
 type persistentVolumeClaimAction interface {
 	ComputeAttributes(corev1.PersistentVolumeClaim) (attributes, error)
 }
@@ -123,6 +126,8 @@ func (proc *K8sEventsProcessor) RunActions(obj metav1.Object) (attributes, error
 		return proc.runDaemonSetActions(*typed)
 	case *appsv1.StatefulSet:
 		return proc.runStatefulSetActions(*typed)
+	case *appsv1.Deployment:
+		return proc.runDeploymentActions(*typed)
 	case *corev1.PersistentVolume:
 		return proc.runPersistentVolumeActions(*typed)
 	case *corev1.PersistentVolumeClaim:
@@ -217,6 +222,18 @@ func (m *K8sEventsProcessor) runPersistentVolumeActions(pvc corev1.PersistentVol
 	res := attributes{}
 	for _, action := range m.persistentVolumeActions {
 		atts, err := action.ComputeAttributes(pvc)
+		if err != nil {
+			return res, err
+		}
+		res.addAttributes(atts)
+	}
+	return res, nil
+}
+
+func (m *K8sEventsProcessor) runDeploymentActions(deployent appsv1.Deployment) (attributes, error) {
+	res := attributes{}
+	for _, action := range m.deploymentActions {
+		atts, err := action.ComputeAttributes(deployent)
 		if err != nil {
 			return res, err
 		}


### PR DESCRIPTION
OTTL's `Len()` doesn't work well with some of the slices obtained by unmarshalling k8s events into their respective API entities. This is because `Len()` doesn't support the type of the inner elements of most of the slices we have to use.
As a result, the only way to "calculate" such lengths is via custom code in our events' processor.