### PR TITLE
fix: update windows install script to leave existing observe-agent.ya…

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,7 +10,6 @@ $local_installer="C:\temp\observe-agent_Windows_x86_64.zip"
 $program_data_filestorage="C:\ProgramData\Observe\observe-agent\filestorage"
 $observeagent_install_dir="$env:ProgramFiles\Observe\observe-agent"
 $temp_dir="C:\temp"
-Write-Output (Test-Path "$observeagent_install_dir\observe-agent.yaml")
 
 New-Item -ItemType Directory -Force -Path $temp_dir
 New-Item -ItemType Directory -Force -Path $observeagent_install_dir

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,9 +5,6 @@ param (
     $observe_token
 )
 
-Write-Output $observe_collection_endpoint
-Write-Output $observe_token
-
 $installer_url="https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Windows_x86_64.zip"
 $local_installer="C:\temp\observe-agent_Windows_x86_64.zip"
 $program_data_filestorage="C:\ProgramData\Observe\observe-agent\filestorage"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,15 +1,19 @@
 param (
-    [Parameter(Mandatory)]
+    [Parameter()]
     $observe_collection_endpoint, 
-    [Parameter(Mandatory)]
+    [Parameter()]
     $observe_token
 )
+
+Write-Output $observe_collection_endpoint
+Write-Output $observe_token
 
 $installer_url="https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Windows_x86_64.zip"
 $local_installer="C:\temp\observe-agent_Windows_x86_64.zip"
 $program_data_filestorage="C:\ProgramData\Observe\observe-agent\filestorage"
 $observeagent_install_dir="$env:ProgramFiles\Observe\observe-agent"
 $temp_dir="C:\temp"
+Write-Output (Test-Path "$observeagent_install_dir\observe-agent.yaml")
 
 New-Item -ItemType Directory -Force -Path $temp_dir
 New-Item -ItemType Directory -Force -Path $observeagent_install_dir
@@ -25,19 +29,30 @@ if((Get-Service ObserveAgent -ErrorAction SilentlyContinue)){
 
 Expand-Archive -Force -LiteralPath $local_installer -DestinationPath "$temp_dir\observe-agent_Windows_x86_64"
 Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\observe-agent.exe -Destination $observeagent_install_dir
-Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\observe-agent.yaml -Destination $observeagent_install_dir
 Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\otel-collector.yaml -Destination $observeagent_install_dir\config\otel-collector.yaml
 Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\connections\ -Destination $observeagent_install_dir\connections -Recurse
 
-# Read the content of the config.yaml file
-$configContent = Get-Content -Path $observeagent_install_dir\observe-agent.yaml -Raw
+# If there's already an observe-agent.yaml we don't copy the template from the downloaded installation package and leave existing observe-agent.yaml alone
+if (-Not (Test-Path "$observeagent_install_dir\observe-agent.yaml"))
+{
+    Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\observe-agent.yaml -Destination $observeagent_install_dir
 
-# Replace ${myhost} with the actual value
-$configContent = $configContent -replace '\${OBSERVE_COLLECTION_ENDPOINT}', $observe_collection_endpoint
-$configContent = $configContent -replace '\${OBSERVE_TOKEN}', $observe_token
+    # We can only insert param templates if there's no existing config and we're copying over the template observe-agent.yaml
+    $configContent = Get-Content -Path $observeagent_install_dir\observe-agent.yaml -Raw
 
-# Write the modified content back to the config.yaml file
-$configContent | Set-Content -Path $observeagent_install_dir\observe-agent.yaml
+    # Replace $OBSERVE_COLLECTION_ENDPOINT and $OBSERVE_TOKEN with param if provided
+    if($PSBoundParameters.ContainsKey('observe_collection_endpoint'))
+    {
+        $configContent = $configContent -replace '\${OBSERVE_COLLECTION_ENDPOINT}', $observe_collection_endpoint
+    }
+    if($PSBoundParameters.ContainsKey('observe_token'))
+    {
+        $configContent = $configContent -replace '\${OBSERVE_TOKEN}', $observe_token
+    }
+
+    # Write the modified content back to the config.yaml file
+    $configContent | Set-Content -Path $observeagent_install_dir\observe-agent.yaml
+}
 
 if(-not (Get-Service ObserveAgent -ErrorAction SilentlyContinue)){
     $params = @{


### PR DESCRIPTION
…ml alone

### Description

OB-36354 Update windows install script to not overwrite existing config files

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary