### PR TITLE
fix: OB-37389 Obfuscate secrets in YAML body

### DIFF
--- a/components/processors/observek8sattributesprocessor/configmapactions_test.go
+++ b/components/processors/observek8sattributesprocessor/configmapactions_test.go
@@ -12,6 +12,6 @@ func TestConfigMapActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/cronjobactions_test.go
+++ b/components/processors/observek8sattributesprocessor/cronjobactions_test.go
@@ -19,6 +19,6 @@ func TestCronJobActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/daemonsetactions_test.go
+++ b/components/processors/observek8sattributesprocessor/daemonsetactions_test.go
@@ -12,6 +12,6 @@ func TestDaemonSetActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/deploymentactions_test.go
+++ b/components/processors/observek8sattributesprocessor/deploymentactions_test.go
@@ -12,6 +12,6 @@ func TestDeploymentActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/endpointsactions_test.go
+++ b/components/processors/observek8sattributesprocessor/endpointsactions_test.go
@@ -12,6 +12,6 @@ func TestEndpointsActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/ingressactions_test.go
+++ b/components/processors/observek8sattributesprocessor/ingressactions_test.go
@@ -19,6 +19,6 @@ func TestIngressActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/jobactions_test.go
+++ b/components/processors/observek8sattributesprocessor/jobactions_test.go
@@ -33,6 +33,6 @@ func TestJobActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/nodeactions_test.go
+++ b/components/processors/observek8sattributesprocessor/nodeactions_test.go
@@ -62,7 +62,7 @@ func TestNodeActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 
 }

--- a/components/processors/observek8sattributesprocessor/persistentvolumeactions_test.go
+++ b/components/processors/observek8sattributesprocessor/persistentvolumeactions_test.go
@@ -19,6 +19,6 @@ func TestPersistentVolumeActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/persistentvolumeclaimactions_test.go
+++ b/components/processors/observek8sattributesprocessor/persistentvolumeclaimactions_test.go
@@ -12,6 +12,6 @@ func TestPersistentVolumeClaimActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/podactions_test.go
+++ b/components/processors/observek8sattributesprocessor/podactions_test.go
@@ -92,7 +92,7 @@ func TestPodActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, test)
+		runTest(t, test, LogLocationAttributes)
 	}
 
 }

--- a/components/processors/observek8sattributesprocessor/secretactions.go
+++ b/components/processors/observek8sattributesprocessor/secretactions.go
@@ -1,0 +1,25 @@
+package observek8sattributesprocessor
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	RedactedSecretValue = "REDACTED"
+)
+
+type SecretRedactorBodyAction struct{}
+
+func NewSecretRedactorBodyAction() SecretRedactorBodyAction {
+	return SecretRedactorBodyAction{}
+}
+
+// ---------------------------------- Secret "data" values' redaction ----------------------------------
+
+// Redacts secrets' values
+func (SecretRedactorBodyAction) Modify(secret *corev1.Secret) error {
+	for key := range secret.Data {
+		secret.Data[key] = []byte(RedactedSecretValue)
+	}
+	return nil
+}

--- a/components/processors/observek8sattributesprocessor/secretactions_test.go
+++ b/components/processors/observek8sattributesprocessor/secretactions_test.go
@@ -1,0 +1,22 @@
+package observek8sattributesprocessor
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+)
+
+func TestSecretBodyActions(t *testing.T) {
+	for _, testCase := range []k8sEventProcessorTest{
+		{
+			name:   "Redact secrets' values",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/secretEvent.json"),
+			expectedResults: []queryWithResult{
+				// This checks that there are no values in "data" that are not "REDACTED"
+				{fmt.Sprintf("length(values(data)[?@ != '%s'])", base64.StdEncoding.EncodeToString([]byte(RedactedSecretValue))), float64(0)},
+			},
+		},
+	} {
+		runTest(t, testCase, LogLocationBody)
+	}
+}

--- a/components/processors/observek8sattributesprocessor/serviceaccountactions_test.go
+++ b/components/processors/observek8sattributesprocessor/serviceaccountactions_test.go
@@ -26,6 +26,6 @@ func TestServiceAccountActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/serviceactions_test.go
+++ b/components/processors/observek8sattributesprocessor/serviceactions_test.go
@@ -40,6 +40,6 @@ func TestServiceActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/statefulsetactions_test.go
+++ b/components/processors/observek8sattributesprocessor/statefulsetactions_test.go
@@ -12,6 +12,6 @@ func TestStatefulSetActions(t *testing.T) {
 			},
 		},
 	} {
-		runTest(t, testCase)
+		runTest(t, testCase, LogLocationAttributes)
 	}
 }

--- a/components/processors/observek8sattributesprocessor/testdata/secretEvent.json
+++ b/components/processors/observek8sattributesprocessor/testdata/secretEvent.json
@@ -1,0 +1,35 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    "OBSERVE_COLLECTOR_HOST": "TmljZSB0cnksIG5lcmQgOikK",
+    "OBSERVE_CUSTOMER": "SSBrbmV3IHNvbWUgZG9yayB3b3VsZCB0cnkgdG8gZGVjb2RlIHRoZXNlCg==",
+    "OBSERVE_TOKEN": "WW91IHJlYWxseSB0aG91Z2h0IEkgd291bGQgbGVhdmUgdGhlIGVuY29kZWQgc2VjcmV0cyBoZXJlPwo="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2024-04-26T17:19:13Z",
+    "managedFields": [
+      {
+        "apiVersion": "v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:data": {
+            ".": {},
+            "f:OBSERVE_COLLECTOR_HOST": {},
+            "f:OBSERVE_CUSTOMER": {},
+            "f:OBSERVE_TOKEN": {}
+          },
+          "f:type": {}
+        },
+        "manager": "kubectl-create",
+        "operation": "Update",
+        "time": "2024-04-26T17:19:13Z"
+      }
+    ],
+    "name": "otel-credentials",
+    "namespace": "eng",
+    "resourceVersion": "20682101",
+    "uid": "someUid"
+  },
+  "type": "Opaque"
+}


### PR DESCRIPTION
Add whole processor framework to modify an event body in place. The set of actions that do that are also type-specific, meaning that we only run relevant actions on any given event, based on the object type.

These actions modify the unmarshalled object IN PLACE and BEFORE the attributes-computing actions do their thing. This is mainly to allow secrets' obfuscation, where we want to prevent secret stuff to end up in the attributes by mistake.

Add secret "body" actions that obfuscate the secrets in "data".

### Description

OB-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary