### PR TITLE
fix: OB-37389 Obfuscate secrets inside Secret previous configuration

### DIFF
--- a/components/processors/observek8sattributesprocessor/secretactions.go
+++ b/components/processors/observek8sattributesprocessor/secretactions.go
@@ -16,10 +16,21 @@ func NewSecretRedactorBodyAction() SecretRedactorBodyAction {
 
 // ---------------------------------- Secret "data" values' redaction ----------------------------------
 
-// Redacts secrets' values
-func (SecretRedactorBodyAction) Modify(secret *corev1.Secret) error {
+func redactSecretKeys(secret *corev1.Secret) {
 	for key := range secret.Data {
 		secret.Data[key] = []byte(RedactedSecretValue)
 	}
+	for key := range secret.StringData {
+		secret.StringData[key] = RedactedSecretValue
+	}
+}
+
+// Redacts secrets' values
+func (SecretRedactorBodyAction) Modify(secret *corev1.Secret) error {
+	redactSecretKeys(secret)
+
+	annotations := secret.GetAnnotations()
+	delete(annotations, corev1.LastAppliedConfigAnnotation)
+	secret.SetAnnotations(annotations)
 	return nil
 }

--- a/components/processors/observek8sattributesprocessor/secretactions_test.go
+++ b/components/processors/observek8sattributesprocessor/secretactions_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSecretBodyActions(t *testing.T) {
@@ -14,6 +16,13 @@ func TestSecretBodyActions(t *testing.T) {
 			expectedResults: []queryWithResult{
 				// This checks that there are no values in "data" that are not "REDACTED"
 				{fmt.Sprintf("length(values(data)[?@ != '%s'])", base64.StdEncoding.EncodeToString([]byte(RedactedSecretValue))), float64(0)},
+			},
+		},
+		{
+			name:   "Redact secrets' last configuration values",
+			inLogs: resourceLogsFromSingleJsonEvent("./testdata/secretEventPrevConfig.json"),
+			expectedResults: []queryWithResult{
+				{fmt.Sprintf("observe_transform.body.metadata.annotations.\"%s\"", corev1.LastAppliedConfigAnnotation), nil},
 			},
 		},
 	} {

--- a/components/processors/observek8sattributesprocessor/testdata/secretEventPrevConfig.json
+++ b/components/processors/observek8sattributesprocessor/testdata/secretEventPrevConfig.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    "postgres-url": "Tm90IHNvIGVhc3kgbXIgaGFja2VyCg==",
+    "postgres-url-proxy": "RGFtbiwgWU9VIFJFQUxMWSBUUklFRCEgQ21vbiBub3cuLi4K"
+  },
+  "kind": "Secret",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"postgres-url\":\"Tm90IHNvIGVhc3kgbXIgaGFja2VyCg==\",\"postgres-url-proxy\":\"RGFtbiwgWU9VIFJFQUxMWSBUUklFRCEgQ21vbiBub3cuLi4K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2021-03-18T20:20:00Z\",\"name\":\"postgres-billing-credentials\",\"namespace\":\"o2\",\"resourceVersion\":\"543685028\",\"uid\":\"619570cd-c3da-43b5-a2a3-f85f68860f30\"},\"type\":\"Opaque\"}\n"
+    },
+    "creationTimestamp": "2024-08-14T20:10:30Z",
+    "managedFields": [
+      {
+        "apiVersion": "v1",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:data": {
+            ".": {},
+            "f:postgres-url": {},
+            "f:postgres-url-proxy": {}
+          },
+          "f:metadata": {
+            "f:annotations": {
+              ".": {},
+              "f:kubectl.kubernetes.io/last-applied-configuration": {}
+            }
+          },
+          "f:type": {}
+        },
+        "manager": "kubectl-client-side-apply",
+        "operation": "Update",
+        "time": "2024-08-14T20:10:30Z"
+      }
+    ],
+    "name": "postgres-billing-credentials",
+    "namespace": "o2",
+    "resourceVersion": "40105",
+    "uid": "638c64d7-14e0-4551-bc9f-7f8e7644c8b9"
+  },
+  "type": "Opaque"
+}


### PR DESCRIPTION
Secret entities not only contain secrets in data, but might also contain
an annotation that represents the previous configuration for this
Secret, including the secrets. Drop such annotation