### PR TITLE
fix: OB-37441 Rename CronJob facet

### DIFF
--- a/components/processors/observek8sattributesprocessor/cronjobactions.go
+++ b/components/processors/observek8sattributesprocessor/cronjobactions.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	CronJobActiveKey = "active"
+	CronJobActiveKey = "activeJobs"
 )
 
 type CronJobActiveAction struct{}

--- a/components/processors/observek8sattributesprocessor/cronjobactions_test.go
+++ b/components/processors/observek8sattributesprocessor/cronjobactions_test.go
@@ -1,21 +1,24 @@
 package observek8sattributesprocessor
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestCronJobActions(t *testing.T) {
 	for _, testCase := range []k8sEventProcessorTest{
 		{
-			name:   "Active CronJob",
+			name:   "Active CronJob jobs",
 			inLogs: resourceLogsFromSingleJsonEvent("./testdata/cronJobEvent.json"),
 			expectedResults: []queryWithResult{
-				{"observe_transform.facets.active", int64(1)},
+				{fmt.Sprintf("observe_transform.facets.%s", CronJobActiveKey), int64(1)},
 			},
 		},
 		{
-			name:   "Idle CronJob",
+			name:   "Idle CronJob jobs",
 			inLogs: resourceLogsFromSingleJsonEvent("./testdata/cronJobEventNotActive.json"),
 			expectedResults: []queryWithResult{
-				{"observe_transform.facets.active", int64(0)},
+				{fmt.Sprintf("observe_transform.facets.%s", CronJobActiveKey), int64(0)},
 			},
 		},
 	} {


### PR DESCRIPTION
Rename CronJob's "active" facet to "activeJobs" for easier understanding/handling