### PR TITLE
fix: update go version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code for the Observe agent and CLI. The agent code is based on the OpenTelemetry
 
 # Build
 
-To run the code you need to have `golang v1.21.7` installed. Then you can run the following command to compile the binary.
+To run the code you need to have `golang v1.22.7` installed. Then you can run the following command to compile the binary.
 
 ```
 go build -o observe-agent


### PR DESCRIPTION
### Description

Updating stale Go version reference in README

### Checklist
- [x] Extended the README / documentation, if necessary