### PR TITLE
feat: add YAML parse check to diagnose command

### DIFF
--- a/internal/commands/diagnose/configcheck.go
+++ b/internal/commands/diagnose/configcheck.go
@@ -16,7 +16,7 @@ type ConfigTestResult struct {
 }
 
 func validateYaml(yamlContent []byte) error {
-	m := make(map[any]any)
+	m := make(map[string]any)
 	return yaml.Unmarshal(yamlContent, &m)
 }
 

--- a/internal/commands/diagnose/configcheck.go
+++ b/internal/commands/diagnose/configcheck.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/observeinc/observe-agent/internal/root"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -21,22 +21,23 @@ func validateYaml(yamlContent []byte) error {
 }
 
 func checkConfig() (any, error) {
-	if root.CfgFile == "" {
+	configFile := viper.ConfigFileUsed()
+	if configFile == "" {
 		return nil, fmt.Errorf("no config file defined")
 	}
-	configFile, err := os.ReadFile(root.CfgFile)
+	contents, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, err
 	}
-	if err = validateYaml(configFile); err != nil {
+	if err = validateYaml(contents); err != nil {
 		return ConfigTestResult{
-			root.CfgFile,
+			configFile,
 			false,
 			err.Error(),
 		}, nil
 	}
 	return ConfigTestResult{
-		ConfigFile: root.CfgFile,
+		ConfigFile: configFile,
 		Passed:     true,
 	}, nil
 }

--- a/internal/commands/diagnose/configcheck.go
+++ b/internal/commands/diagnose/configcheck.go
@@ -1,0 +1,58 @@
+package diagnose
+
+import (
+	"embed"
+	"fmt"
+	"os"
+
+	"github.com/observeinc/observe-agent/internal/root"
+	"gopkg.in/yaml.v2"
+)
+
+type ConfigTestResult struct {
+	ConfigFile string
+	Passed     bool
+	Error      string
+}
+
+func validateYaml(yamlContent []byte) error {
+	m := make(map[any]any)
+	return yaml.Unmarshal(yamlContent, &m)
+}
+
+func checkConfig() (any, error) {
+	if root.CfgFile == "" {
+		return nil, fmt.Errorf("no config file defined")
+	}
+	configFile, err := os.ReadFile(root.CfgFile)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateYaml(configFile); err != nil {
+		return ConfigTestResult{
+			root.CfgFile,
+			false,
+			err.Error(),
+		}, nil
+	}
+	return ConfigTestResult{
+		ConfigFile: root.CfgFile,
+		Passed:     true,
+	}, nil
+}
+
+const configcheckTemplate = "configcheck.tmpl"
+
+var (
+	//go:embed configcheck.tmpl
+	configcheckTemplateFS embed.FS
+)
+
+func configDiagnostic() Diagnostic {
+	return Diagnostic{
+		check:        checkConfig,
+		checkName:    "Config Check",
+		templateName: configcheckTemplate,
+		templateFS:   configcheckTemplateFS,
+	}
+}

--- a/internal/commands/diagnose/configcheck.tmpl
+++ b/internal/commands/diagnose/configcheck.tmpl
@@ -1,0 +1,6 @@
+Running check on config file {{ .ConfigFile }}
+{{- if .Passed }}
+Config file is valid YAML.
+{{- else }}
+⚠️ Config file parse failed with error {{ .Error }}
+{{- end }}

--- a/internal/commands/diagnose/configcheck_test.go
+++ b/internal/commands/diagnose/configcheck_test.go
@@ -1,0 +1,59 @@
+package diagnose
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testConfig = `
+# Observe data token
+token: "some token"
+
+# Target Observe collection url
+observe_url: "localhost"
+
+# Debug mode - Sets agent log level to debug
+debug: false
+
+# collect metrics and logs pertaining to the agent itself
+self_monitoring:
+  enabled: true
+
+# collect metrics and logs about the host system
+host_monitoring:
+  enabled: true
+  # collect logs of all running processes from the host system
+  logs: 
+    enabled: true
+  metrics:
+    # collect metrics about the host system
+    host:
+      enabled: true
+    # collect metrics about the processes running on the host system
+    process:
+      enabled: false
+`
+
+var (
+	validCases = []string{
+		testConfig,
+		"key:\n  spaceIndented: \"value\"",
+	}
+	invalidCases = []string{
+		"key:\n\ttabIndented: \"value\"",
+		"key:\n  twoSpaces: true\n   threeSpaces: true",
+		"\tstartsWithTab: true",
+	}
+)
+
+func Test_validateYaml(t *testing.T) {
+	for _, tc := range validCases {
+		err := validateYaml([]byte(tc))
+		assert.NoError(t, err)
+	}
+	for _, tc := range invalidCases {
+		err := validateYaml([]byte(tc))
+		assert.Error(t, err)
+	}
+}

--- a/internal/commands/diagnose/diagnose.go
+++ b/internal/commands/diagnose/diagnose.go
@@ -22,6 +22,7 @@ type Diagnostic struct {
 
 var diagnostics = []Diagnostic{
 	authDiagnostic(),
+	configDiagnostic(),
 }
 
 // diagnoseCmd represents the diagnose command


### PR DESCRIPTION
### Description

OB-37709 add a new check to the diagnose command to check if the config file is valid YAML.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary