### PR TITLE
fix: add a description to the root command

### DIFF
--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -17,16 +17,9 @@ var CfgFile string
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "observe-agent",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Short: "A runner for the Observe agent process along with CLI utils.",
+	Long: `A runner for the Observe agent process along with CLI utils to help with setup
+and maintenance. To start the agent, run: observe-agent start`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -17,8 +17,8 @@ var CfgFile string
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "observe-agent",
-	Short: "A runner for the Observe agent process along with CLI utils.",
-	Long: `A runner for the Observe agent process along with CLI utils to help with setup
+	Short: "Observe distribution of OTEL Collector",
+	Long: `Observe distribution of OTEL Collector along with CLI utils to help with setup
 and maintenance. To start the agent, run: observe-agent start`,
 }
 


### PR DESCRIPTION
### Description

OB-37820 Here's how it looks now:

```
$ ./observe-agent help
Observe distribution of OTEL Collector along with CLI utils to help with setup
and maintenance. To start the agent, run: observe-agent start

Usage:
  observe-agent [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  diagnose    Run diagnostic checks.
  help        Help about any command
  init-config Initialize agent configuration
  start       Start the Observe agent process.
  status      Display status of agent
  version     Display the currently installed version of the observe-agent.

Flags:
      --config string   config file path
  -h, --help            help for observe-agent
  -t, --toggle          Help message for toggle

Use "observe-agent [command] --help" for more information about a command.
```