### PR TITLE
fix: allow more users to trigger the Github nightly build action

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   goreleaser:
-    if: contains('["obs-gh-alexlew"]', github.actor)
+    if: contains('["obs-gh-alexlew", "obs-gh-mattcotter"]', github.actor)
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

Adding @obs-gh-mattcotter to the list for release-nightly.yaml

Example run without this change where the release is skipped: https://github.com/observeinc/observe-agent/actions/runs/11448694510
