### PR TITLE
feat: validate the otel configuration in diagnose

### DIFF
--- a/internal/commands/diagnose/diagnose.go
+++ b/internal/commands/diagnose/diagnose.go
@@ -23,6 +23,7 @@ type Diagnostic struct {
 
 var diagnostics = []Diagnostic{
 	configDiagnostic(),
+	otelconfigDiagnostic(),
 	authDiagnostic(),
 }
 

--- a/internal/commands/diagnose/otelconfigcheck.go
+++ b/internal/commands/diagnose/otelconfigcheck.go
@@ -22,7 +22,8 @@ func checkOtelConfig(_ *viper.Viper) (any, error) {
 	if cleanup != nil {
 		defer cleanup()
 	}
-	// Copying the implementation from the `otelcol validate` command
+	// These are the same checks as the `otelcol validate` command:
+	// https://github.com/open-telemetry/opentelemetry-collector/blob/main/otelcol/command_validate.go
 	col, err := otelcol.NewCollector(*colSettings)
 	if err != nil {
 		return nil, err

--- a/internal/commands/diagnose/otelconfigcheck.go
+++ b/internal/commands/diagnose/otelconfigcheck.go
@@ -1,0 +1,56 @@
+package diagnose
+
+import (
+	"context"
+	"embed"
+
+	"github.com/observeinc/observe-agent/internal/commands/start"
+	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/otelcol"
+)
+
+type OtelConfigTestResult struct {
+	Passed bool
+	Error  string
+}
+
+func checkOtelConfig(_ *viper.Viper) (any, error) {
+	colSettings, cleanup, err := start.SetupAndGenerateCollectorSettings()
+	if err != nil {
+		return nil, err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	// Copying the implementation from the `otelcol validate` command
+	col, err := otelcol.NewCollector(*colSettings)
+	if err != nil {
+		return nil, err
+	}
+	err = col.DryRun(context.Background())
+	if err != nil {
+		return OtelConfigTestResult{
+			Passed: false,
+			Error:  err.Error(),
+		}, nil
+	}
+	return OtelConfigTestResult{
+		Passed: true,
+	}, nil
+}
+
+const otelconfigcheckTemplate = "otelconfigcheck.tmpl"
+
+var (
+	//go:embed otelconfigcheck.tmpl
+	otelconfigcheckTemplateFS embed.FS
+)
+
+func otelconfigDiagnostic() Diagnostic {
+	return Diagnostic{
+		check:        checkOtelConfig,
+		checkName:    "OTEL Config Check",
+		templateName: otelconfigcheckTemplate,
+		templateFS:   otelconfigcheckTemplateFS,
+	}
+}

--- a/internal/commands/diagnose/otelconfigcheck.tmpl
+++ b/internal/commands/diagnose/otelconfigcheck.tmpl
@@ -1,0 +1,5 @@
+{{- if .Passed }}
+OTEL configuration is valid.
+{{- else }}
+⚠️ OTEL configuration validation failed with error {{ .Error }}
+{{- end }}


### PR DESCRIPTION
### Description

OB-31850 Validate all OTEL configuration in the `diagnose` command

Example output:

> ⚠️ OTEL configuration validation failed with error service::pipelines::metrics: references receiver "filelog" which is not configured

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary