### PR TITLE
feat: add new config command to print out all configuration

### DIFF
--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -1,0 +1,49 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/observeinc/observe-agent/internal/commands/start"
+	logger "github.com/observeinc/observe-agent/internal/commands/util"
+	"github.com/observeinc/observe-agent/internal/root"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Prints the full configuration for this agent.",
+	Long: `This command prints all configuration for this agent including any additional
+OTEL configuration.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := logger.WithCtx(context.Background(), logger.GetNop())
+		configFilePaths, cleanup, err := start.SetupAndGetConfigFiles(ctx)
+		if err != nil {
+			return err
+		}
+		if cleanup != nil {
+			defer cleanup()
+		}
+		agentConfig := viper.ConfigFileUsed()
+		configFilePaths = append([]string{agentConfig}, configFilePaths...)
+		for _, filePath := range configFilePaths {
+			file, err := os.ReadFile(filePath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error reading config file %s: %s", filePath, err.Error())
+			} else {
+				fmt.Printf("# ======== config file %s\n", filePath)
+				fmt.Println(string(file))
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	root.RootCmd.AddCommand(configCmd)
+}

--- a/internal/commands/util/logger.go
+++ b/internal/commands/util/logger.go
@@ -18,6 +18,10 @@ func GetDev() *zap.Logger {
 	return logger
 }
 
+func GetNop() *zap.Logger {
+	return zap.NewNop()
+}
+
 func FromCtx(ctx context.Context) *zap.Logger {
 	if l, ok := ctx.Value(ctxKey{}).(*zap.Logger); ok {
 		return l

--- a/internal/connections/confighandler.go
+++ b/internal/connections/confighandler.go
@@ -1,4 +1,4 @@
-package config
+package connections
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/observeinc/observe-agent/internal/connections"
+	logger "github.com/observeinc/observe-agent/internal/commands/util"
 	"github.com/spf13/viper"
 )
 
@@ -17,7 +17,7 @@ func GetAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, st
 	configFilePaths := []string{filepath.Join(GetDefaultConfigFolder(), "otel-collector.yaml")}
 	var err error
 	// Get additional config paths based on connection configs
-	for _, conn := range connections.AllConnectionTypes {
+	for _, conn := range AllConnectionTypes {
 		if viper.IsSet(conn.Name) {
 			connectionPaths, err := conn.GetConfigFilePaths(ctx, tmpDir)
 			if err != nil {
@@ -39,7 +39,7 @@ func GetAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, st
 		}
 		configFilePaths = append(configFilePaths, overridePath)
 	}
-	fmt.Println("Config file paths:", configFilePaths)
+	logger.FromCtx(ctx).Info(fmt.Sprint("Config file paths:", configFilePaths))
 	return configFilePaths, overridePath, nil
 }
 

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	logger "github.com/observeinc/observe-agent/internal/commands/util"
+	"github.com/observeinc/observe-agent/internal/config"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
@@ -97,7 +98,7 @@ func (c *ConnectionType) GetConfigFilePaths(ctx context.Context, tmpDir string) 
 	}
 	switch c.Type {
 	case SelfMonitoringConnectionTypeName:
-		conf := &SelfMonitoringConfig{}
+		conf := &config.SelfMonitoringConfig{}
 		err := rawConnConfig.Unmarshal(conf)
 		if err != nil {
 			logger.FromCtx(ctx).Error("failed to unmarshal config", zap.String("connection", c.Name))
@@ -108,7 +109,7 @@ func (c *ConnectionType) GetConfigFilePaths(ctx context.Context, tmpDir string) 
 			return nil, err
 		}
 	case HostMonitoringConnectionTypeName:
-		conf := &HostMonitoringConfig{}
+		conf := &config.HostMonitoringConfig{}
 		err := rawConnConfig.Unmarshal(conf)
 		if err != nil {
 			logger.FromCtx(ctx).Error("failed to unmarshal config", zap.String("connection", c.Name))

--- a/internal/connections/hostmonitoring.go
+++ b/internal/connections/hostmonitoring.go
@@ -2,16 +2,6 @@ package connections
 
 var HostMonitoringConnectionTypeName = "host_monitoring"
 
-type HostMonitoringConfig struct {
-	enabled bool
-	metrics struct {
-		enabled bool
-	}
-	logs struct {
-		enabled bool
-	}
-}
-
 var HostMonitoringConnectionType = MakeConnectionType(
 	"host_monitoring",
 	[]CollectorConfigFragment{

--- a/internal/connections/selfmonitoring.go
+++ b/internal/connections/selfmonitoring.go
@@ -2,10 +2,6 @@ package connections
 
 var SelfMonitoringConnectionTypeName = "self_monitoring"
 
-type SelfMonitoringConfig struct {
-	enabled bool
-}
-
 var SelfMonitoringConnectionType = MakeConnectionType(
 	"self_monitoring",
 	[]CollectorConfigFragment{

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/observeinc/observe-agent/internal/config"
+	"github.com/observeinc/observe-agent/internal/connections"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -47,7 +47,7 @@ func InitConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(CfgFile)
 	} else {
-		viper.AddConfigPath(config.GetDefaultAgentPath())
+		viper.AddConfigPath(connections.GetDefaultAgentPath())
 		viper.SetConfigType("yaml")
 		viper.SetConfigName("observe-agent")
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package main
 
 import (
+	_ "github.com/observeinc/observe-agent/internal/commands/config"
 	_ "github.com/observeinc/observe-agent/internal/commands/diagnose"
 	_ "github.com/observeinc/observe-agent/internal/commands/initconfig"
 	_ "github.com/observeinc/observe-agent/internal/commands/start"


### PR DESCRIPTION
### Description

OB-37220 add a new config command to print out all configuration

This naming matches the `datadog-agent config` command. Having this will facilitate debugging as we start to add templated data to our OTEL config fragments.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary