### PR TITLE
feat: add include field to observe agent config that propagates to OTEL host log receiver

### DIFF
--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -8,7 +8,8 @@ import (
 )
 
 type HostMonitoringLogsConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled bool     `yaml:"enabled"`
+	Include []string `yaml:"include,omitempty"`
 }
 
 type HostMonitoringHostMetricsConfig struct {

--- a/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
@@ -1,6 +1,11 @@
 receivers:
   filelog/host_monitoring:
-    include: [/hostfs/var/log/**/*.log, /hostfs/var/log/syslog]
+    include:
+      - /hostfs/var/log/**/*.log
+      - /hostfs/var/log/syslog]
+      {{- range .Logs.Include }}
+      - {{ . }}
+      {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
@@ -1,6 +1,11 @@
 receivers:
   filelog/host_monitoring:
-    include: [/var/log/**/*.log, /var/log/syslog]
+    include:
+      - /var/log/**/*.log
+      - /var/log/syslog
+      {{- range .Logs.Include }}
+      - {{ . }}
+      {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:


### PR DESCRIPTION
### Description

OB-37220 add include field to observe agent config that propagates to OTEL host log receiver

This enables us to use the agent config to list logs files.
Ex:
```yaml
# agent config
host_monitoring:
  enabled: true
  logs: 
    enabled: true
    include: ["/log/test.log"]

# otel config snippet (generated via `observe-agent config`)
receivers:
  filelog/host_monitoring:
    include:
      - /var/log/**/*.log
      - /var/log/syslog
      - /log/test.log
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary