### PR TITLE
feat: add include field to observe agent config that propagates to OTEL host log receiver

### DIFF
--- a/internal/commands/initconfig/initconfig.go
+++ b/internal/commands/initconfig/initconfig.go
@@ -21,6 +21,7 @@ var (
 	self_monitoring_enabled                 bool
 	host_monitoring_enabled                 bool
 	host_monitoring_logs_enabled            bool
+	host_monitoring_logs_include            []string
 	host_monitoring_metrics_host_enabled    bool
 	host_monitoring_metrics_process_enabled bool
 	//go:embed observe-agent.tmpl
@@ -35,6 +36,7 @@ type FlatAgentConfig struct {
 	SelfMonitoring_Enabled                bool
 	HostMonitoring_Enabled                bool
 	HostMonitoring_LogsEnabled            bool
+	HostMonitoring_LogsInclude            []string
 	HostMonitoring_Metrics_HostEnabled    bool
 	HostMonitoring_Metrics_ProcessEnabled bool
 }
@@ -53,6 +55,9 @@ func NewConfigureCmd() *cobra.Command {
 				HostMonitoring_LogsEnabled:            viper.GetBool("host_monitoring::logs::enabled"),
 				HostMonitoring_Metrics_HostEnabled:    viper.GetBool("host_monitoring::metrics::host::enabled"),
 				HostMonitoring_Metrics_ProcessEnabled: viper.GetBool("host_monitoring::metrics::process::enabled"),
+			}
+			if configValues.HostMonitoring_LogsEnabled {
+				configValues.HostMonitoring_LogsInclude = viper.GetStringSlice("host_monitoring::logs::include")
 			}
 			var outputPath string
 			if config_path != "" {
@@ -88,6 +93,7 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&self_monitoring_enabled, "self_monitoring::enabled", true, "Enable self monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_enabled, "host_monitoring::enabled", true, "Enable host monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_logs_enabled, "host_monitoring::logs::enabled", true, "Enable host monitoring logs")
+	cmd.PersistentFlags().StringSliceVar(&host_monitoring_logs_include, "host_monitoring::logs::include", nil, "Set host monitoring log include paths")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_host_enabled, "host_monitoring::metrics::host::enabled", true, "Enable host monitoring host metrics")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_process_enabled, "host_monitoring::metrics::process::enabled", false, "Enable host monitoring process metrics")
 	viper.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
@@ -95,6 +101,7 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	viper.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))
+	viper.BindPFlag("host_monitoring::logs::include", cmd.PersistentFlags().Lookup("host_monitoring::logs::include"))
 	viper.BindPFlag("host_monitoring::metrics::host::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::host::enabled"))
 	viper.BindPFlag("host_monitoring::metrics::process::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::process::enabled"))
 }

--- a/internal/commands/initconfig/initconfig_test.go
+++ b/internal/commands/initconfig/initconfig_test.go
@@ -19,7 +19,7 @@ func Test_InitConfigCommand(t *testing.T) {
 		expectErr      string
 	}{
 		{
-			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url"},
+			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url", "--host_monitoring::logs::include=/test/path,/test/path2"},
 			expectedConfig: config.AgentConfig{
 				Token:      "test-token",
 				ObserveURL: "test-url",
@@ -30,6 +30,7 @@ func Test_InitConfigCommand(t *testing.T) {
 					Enabled: true,
 					Logs: config.HostMonitoringLogsConfig{
 						Enabled: true,
+						Include: []string{"/test/path", "/test/path2"},
 					},
 					Metrics: config.HostMonitoringMetricsConfig{
 						Host: config.HostMonitoringHostMetricsConfig{

--- a/internal/commands/initconfig/observe-agent.tmpl
+++ b/internal/commands/initconfig/observe-agent.tmpl
@@ -14,6 +14,12 @@ host_monitoring:
   enabled: {{ .HostMonitoring_Enabled }}
   logs: 
     enabled: {{ .HostMonitoring_LogsEnabled }}
+    {{- if .HostMonitoring_LogsInclude }}
+    include:
+    {{- range .HostMonitoring_LogsInclude }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
   metrics:
     host:
       enabled: {{ .HostMonitoring_Metrics_HostEnabled }}

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -8,7 +8,8 @@ import (
 )
 
 type HostMonitoringLogsConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled bool     `yaml:"enabled"`
+	Include []string `yaml:"include,omitempty"`
 }
 
 type HostMonitoringHostMetricsConfig struct {

--- a/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
@@ -1,6 +1,14 @@
 receivers:
   filelog/host_monitoring:
-    include: [/hostfs/var/log/**/*.log, /hostfs/var/log/syslog]
+    include:
+      {{- if .Logs.Include }}
+      {{- range .Logs.Include }}
+      - {{ . }}
+      {{- end }}
+      {{- else }}
+      - /hostfs/var/log/**/*.log
+      - /hostfs/var/log/syslog]
+      {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:

--- a/packaging/linux/config/observe-agent.yaml
+++ b/packaging/linux/config/observe-agent.yaml
@@ -15,8 +15,11 @@ self_monitoring:
 host_monitoring:
   enabled: true
   # collect logs of all running processes from the host system
-  logs: 
+  logs:
     enabled: true
+    include:
+      - /var/log/**/*.log
+      - /var/log/syslog
   metrics:
     # collect metrics about the host system
     host:
@@ -24,7 +27,7 @@ host_monitoring:
     # collect metrics about the processes running on the host system
     process:
       enabled: false
-    
+
 # otel_config_overrides:
 #   exporters:
 #     # This is a net new exporter

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
@@ -1,6 +1,14 @@
 receivers:
   filelog/host_monitoring:
-    include: [/var/log/**/*.log, /var/log/syslog]
+    include:
+      {{- if .Logs.Include }}
+      {{- range .Logs.Include }}
+      - {{ . }}
+      {{- end }}
+      {{- else }}
+      - /var/log/**/*.log
+      - /var/log/syslog
+      {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:


### PR DESCRIPTION
### Description

OB-37220 add include field to observe agent config that propagates to OTEL host log receiver

This is like #120 (which was closed accidentally), but also includes changes to `init-config` to handle default log files.

This enables us to use the agent config to list logs files.
Ex:
```yaml
# agent config
host_monitoring:
  enabled: true
  logs: 
    enabled: true
    include: ["/log/test.log"]

# otel config snippet (generated via `observe-agent config`)
receivers:
  filelog/host_monitoring:
    include:
      - /log/test.log
```

Without the `include` specified in the agent config, we still get the correct defaults, ie:
```
receivers:
  filelog/host_monitoring:
    include:
      - /var/log/**/*.log
      - /var/log/syslog
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary