### PR TITLE
fix: Override log body with structured object

### DIFF
--- a/components/processors/observek8sattributesprocessor/types.go
+++ b/components/processors/observek8sattributesprocessor/types.go
@@ -116,15 +116,14 @@ type secretBodyAction interface {
 // This is useful, for instance, when we want to redact secrets' values, to
 // prevent generating attributes that contain secret's values before redacting
 // them.
-// TODO [eg] check if there's actually no copying going on here
-func (proc *K8sEventsProcessor) RunBodyActions(obj metav1.Object) error {
+// Returns true if the object was modified by any action, false otherwise
+func (proc *K8sEventsProcessor) RunBodyActions(obj metav1.Object) (bool, error) {
 	switch typed := obj.(type) {
 	case *corev1.Secret:
-		err := proc.runSecretBodyActions(typed)
-		return err
+		return true, proc.runSecretBodyActions(typed)
 	}
 
-	return nil
+	return false, nil
 }
 
 func (m *K8sEventsProcessor) runSecretBodyActions(secret *corev1.Secret) error {


### PR DESCRIPTION
Currently we were modifying the marshalled k8s object and then overriding the log body with its unmarshalled string representation.

This doesn't work well when the custom processor is not last in the pipeline, because other processors might have to index into the structured body to be able to extract values.

Since we need to move the transform processor after the custom processor in the agent configmap, we want to make sure that this processor leaves the log body as a structured object, rather than a plain string.

### Description

OB-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary