### PR TITLE
feat: add computed viper config output to config command

### DIFF
--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/observeinc/observe-agent/internal/root"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 var configCmd = &cobra.Command{
@@ -29,6 +30,16 @@ OTEL configuration.`,
 		if cleanup != nil {
 			defer cleanup()
 		}
+		var viperConfig map[string]any
+		if err := viper.Unmarshal(&viperConfig); err != nil {
+			return err
+		}
+		viperConfigYaml, err := yaml.Marshal(viperConfig)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("# ======== computed agent config\n")
+		fmt.Println(string(viperConfigYaml) + "\n")
 		agentConfig := viper.ConfigFileUsed()
 		configFilePaths = append([]string{agentConfig}, configFilePaths...)
 		for _, filePath := range configFilePaths {


### PR DESCRIPTION
### Description

OB-37220 add computed viper config output to config command.

This makes it easier to see when env vars are substituted for values in the config file.

Ex:
```
$ TOKEN="test_token" ./observe-agent config
# ======== computed agent config
host_monitoring:
    enabled: true
    logs:
        enabled: true
    metrics:
        host:
            enabled: true
        process:
            enabled: false
observe_url: ""
otelconfigfile: ""
self_monitoring:
    enabled: true
token: test_token
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary