### PR TITLE
ci: update windows 2016 ami

### DIFF
--- a/integration/modules/create_ec2/locals.tf
+++ b/integration/modules/create_ec2/locals.tf
@@ -89,7 +89,7 @@ locals {
 
     WINDOWS_SERVER_2016_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-07357c8c8d7501f94"
+      ami_id            = "ami-02884c2ff86636807"
       ami_description   = "Microsoft Windows Server 2016 with Desktop Experience Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120


### PR DESCRIPTION
### Description

Previous Windows 2016 AMI is no longer being used. Update to new AMI 