### PR TITLE
feat: add agent-config var to override default resourcedetection/cloud::detectors

### DIFF
--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 type HostMonitoringLogsConfig struct {
@@ -36,11 +39,36 @@ type SelfMonitoringConfig struct {
 }
 
 type AgentConfig struct {
-	Token               string               `yaml:"token"`
-	ObserveURL          string               `yaml:"observe_url"`
-	SelfMonitoring      SelfMonitoringConfig `yaml:"self_monitoring,omitempty"`
-	HostMonitoring      HostMonitoringConfig `yaml:"host_monitoring,omitempty"`
-	OtelConfigOverrides map[string]any       `yaml:"otel_config_overrides,omitempty"`
+	Token                  string               `yaml:"token"`
+	ObserveURL             string               `yaml:"observe_url"`
+	CloudResourceDetectors []string             `yaml:"cloud_resource_detectors,omitempty"`
+	SelfMonitoring         SelfMonitoringConfig `yaml:"self_monitoring,omitempty"`
+	HostMonitoring         HostMonitoringConfig `yaml:"host_monitoring,omitempty"`
+	OtelConfigOverrides    map[string]any       `yaml:"otel_config_overrides,omitempty"`
+}
+
+func UnmarshalViperThroughYaml(v *viper.Viper, out any) error {
+	// First unmarshal viper into a map
+	var viperConfig map[string]any
+	if err := viper.Unmarshal(&viperConfig); err != nil {
+		return err
+	}
+	// Next convert the map into yaml bytes
+	viperConfigYaml, err := yaml.Marshal(viperConfig)
+	if err != nil {
+		return err
+	}
+	// Finally unmarshal the yaml bytes into the out struct
+	return yaml.Unmarshal(viperConfigYaml, out)
+}
+
+func AgentConfigFromViper(v *viper.Viper) (*AgentConfig, error) {
+	var config AgentConfig
+	err := UnmarshalViperThroughYaml(v, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
 }
 
 func (config *AgentConfig) Validate() error {

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -67,7 +67,11 @@ processors:
           enabled: true
   
   resourcedetection/cloud:
-    detectors: ["gcp", "ecs", "ec2", "azure"]
+    detectors:
+    {{- if .CloudResourceDetectors }}
+    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- else }} ["gcp", "ecs", "ec2", "azure"]
+    {{- end }}
     timeout: 2s
     override: false
     

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -67,7 +67,11 @@ processors:
           enabled: true
   
   resourcedetection/cloud:
-    detectors: ["gcp", "ecs", "ec2", "azure"]
+    detectors:
+    {{- if .CloudResourceDetectors }}
+    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- else }} ["gcp", "ecs", "ec2", "azure"]
+    {{- end }}
     timeout: 2s
     override: false
 

--- a/packaging/windows/config/otel-collector.yaml
+++ b/packaging/windows/config/otel-collector.yaml
@@ -47,7 +47,11 @@ processors:
           enabled: true
   
   resourcedetection/cloud:
-    detectors: ["gcp", "ecs", "ec2", "azure"]
+    detectors:
+    {{- if .CloudResourceDetectors }}
+    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- else }} ["gcp", "ecs", "ec2", "azure"]
+    {{- end }}
     timeout: 2s
     override: false
 


### PR DESCRIPTION
### Description

OB-36552 add agent-config var to override default resourcedetection/cloud::detectors

**Example**

With no agent config changes, the detectors are defaulted:
```yaml
  resourcedetection/cloud:
    detectors: ["gcp", "ecs", "ec2", "azure"]
```

But after adding this to the agent config:
```yaml
cloud_resource_detectors:
  - azure
  - ec2
```
The detectors become
```yaml
  resourcedetection/cloud:
    detectors:[azure,ec2]
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary