### PR TITLE
fix: skip deb and rpm publishing on nightly release

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -22,7 +22,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.0.0
+          version: 2.4.4
           args: changelog
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '2.0.0'
+          version: '2.4.4'
           args: release --prepare --clean --snapshot --verbose
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.0.0
+          version: 2.4.4
           args: release --clean --skip=validate --verbose --nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.0.0
+          version: 2.4.4
           args: release --clean --skip=validate --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '2.0.0'
+          version: '2.4.4'
           args: release --prepare --clean --snapshot --verbose --parallelism 8
         env:         
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@
 
 # The lines below are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/need to use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
 version: 2
@@ -1154,3 +1154,4 @@ brews:
 
 furies:
   - account: observeinc
+    disable: "{{ .IsNightly }}"


### PR DESCRIPTION
### Description

OB-38483 skip deb and rpm publishing on nightly release

I will test this by running the action when this change lands.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary