### PR TITLE
Makefile: install-ocb target -> add ~/bin directory creation before curl output…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ release:
 
 ## install-ocb: Installs correct version of ocb binary
 install-ocb:
+	@mkdir -p "$(HOME)/bin"
 	curl --proto '=https' --tlsv1.2 -L -o "$(HOME)/bin/ocb" https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.110.0/ocb_0.110.0_darwin_arm64
 	@chmod +x "$(HOME)/bin/ocb"
 


### PR DESCRIPTION
… targets it

### Description

Problem: "install-ocb" makefile target assumes existence of ~/bin directory - fails if doesn't exist
Fix: add non-destructive creation of ~/bin directory before curl tries to output there

### Checklist
- [NA] Created tests which fail without the change (if possible)
- [NA] Extended the README / documentation, if necessary