### PR TITLE
fix: fix whitespace typo when customizing CloudResourceDetectors

### DIFF
--- a/integration/scripts/test_configure.py
+++ b/integration/scripts/test_configure.py
@@ -4,7 +4,7 @@ import utils as u
 
 @u.print_test_decorator
 def run_test_windows(remote_host: u.Host, env_vars: dict) -> None:
-    init_command = r'Set-Location "C:\Program Files\Observe\observe-agent"; ./observe-agent init-config --token {} --observe_url {}'.format(
+    init_command = r'Set-Location "C:\Program Files\Observe\observe-agent"; ./observe-agent init-config --token {} --observe_url {} --cloud_resource_detectors ec2'.format(
         env_vars["observe_token"], env_vars["observe_url"]
     )
 
@@ -18,7 +18,7 @@ def run_test_windows(remote_host: u.Host, env_vars: dict) -> None:
 @u.print_test_decorator
 def run_test_docker(remote_host: u.Host, env_vars: dict) -> None:
     docker_prefix = u.get_docker_prefix(remote_host, False)
-    init_command = "{} init-config --token {} --observe_url {}".format(
+    init_command = "{} init-config --token {} --observe_url {} --cloud_resource_detectors ec2".format(
         docker_prefix, env_vars["observe_token"], env_vars["observe_url"]
     )
 
@@ -31,7 +31,7 @@ def run_test_docker(remote_host: u.Host, env_vars: dict) -> None:
 
 @u.print_test_decorator
 def run_test_linux(remote_host: u.Host, env_vars: dict) -> None:
-    init_command = "sudo observe-agent init-config --token {} --observe_url {}".format(
+    init_command = "sudo observe-agent init-config --token {} --observe_url {} --cloud_resource_detectors ec2".format(
         env_vars["observe_token"], env_vars["observe_url"]
     )
 

--- a/internal/commands/initconfig/initconfig.go
+++ b/internal/commands/initconfig/initconfig.go
@@ -43,30 +43,30 @@ type FlatAgentConfig struct {
 	HostMonitoring_Metrics_ProcessEnabled bool
 }
 
-func NewConfigureCmd() *cobra.Command {
+func NewConfigureCmd(v *viper.Viper) *cobra.Command {
 	return &cobra.Command{
 		Use:   "init-config",
 		Short: "Initialize agent configuration",
 		Long:  `This command takes in parameters and creates an initialized observe agent configuration file. Will overwrite existing config file and should only be used to initialize.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configValues := FlatAgentConfig{
-				Token:                                 viper.GetString("token"),
-				ObserveURL:                            viper.GetString("observe_url"),
-				CloudResourceDetectors:                viper.GetStringSlice("cloud_resource_detectors"),
-				SelfMonitoring_Enabled:                viper.GetBool("self_monitoring::enabled"),
-				HostMonitoring_Enabled:                viper.GetBool("host_monitoring::enabled"),
-				HostMonitoring_LogsEnabled:            viper.GetBool("host_monitoring::logs::enabled"),
-				HostMonitoring_Metrics_HostEnabled:    viper.GetBool("host_monitoring::metrics::host::enabled"),
-				HostMonitoring_Metrics_ProcessEnabled: viper.GetBool("host_monitoring::metrics::process::enabled"),
+				Token:                                 v.GetString("token"),
+				ObserveURL:                            v.GetString("observe_url"),
+				CloudResourceDetectors:                v.GetStringSlice("cloud_resource_detectors"),
+				SelfMonitoring_Enabled:                v.GetBool("self_monitoring::enabled"),
+				HostMonitoring_Enabled:                v.GetBool("host_monitoring::enabled"),
+				HostMonitoring_LogsEnabled:            v.GetBool("host_monitoring::logs::enabled"),
+				HostMonitoring_Metrics_HostEnabled:    v.GetBool("host_monitoring::metrics::host::enabled"),
+				HostMonitoring_Metrics_ProcessEnabled: v.GetBool("host_monitoring::metrics::process::enabled"),
 			}
 			if configValues.HostMonitoring_LogsEnabled {
-				configValues.HostMonitoring_LogsInclude = viper.GetStringSlice("host_monitoring::logs::include")
+				configValues.HostMonitoring_LogsInclude = v.GetStringSlice("host_monitoring::logs::include")
 			}
 			var outputPath string
 			if config_path != "" {
 				outputPath = config_path
 			} else {
-				outputPath = viper.ConfigFileUsed()
+				outputPath = v.ConfigFileUsed()
 			}
 			f, err := os.Create(outputPath)
 			if err != nil {
@@ -84,12 +84,13 @@ func NewConfigureCmd() *cobra.Command {
 }
 
 func init() {
-	configureCmd := NewConfigureCmd()
-	RegisterConfigFlags(configureCmd)
+	v := viper.GetViper()
+	configureCmd := NewConfigureCmd(v)
+	RegisterConfigFlags(configureCmd, v)
 	root.RootCmd.AddCommand(configureCmd)
 }
 
-func RegisterConfigFlags(cmd *cobra.Command) {
+func RegisterConfigFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().StringVarP(&config_path, "config_path", "", "", "Path to write config output file to")
 	cmd.PersistentFlags().StringVar(&token, "token", "", "Observe token")
 	cmd.PersistentFlags().StringVar(&observe_url, "observe_url", "", "Observe data collection url")
@@ -100,13 +101,13 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSliceVar(&host_monitoring_logs_include, "host_monitoring::logs::include", nil, "Set host monitoring log include paths")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_host_enabled, "host_monitoring::metrics::host::enabled", true, "Enable host monitoring host metrics")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_process_enabled, "host_monitoring::metrics::process::enabled", false, "Enable host monitoring process metrics")
-	viper.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
-	viper.BindPFlag("observe_url", cmd.PersistentFlags().Lookup("observe_url"))
-	viper.BindPFlag("cloud_resource_detectors", cmd.PersistentFlags().Lookup("cloud_resource_detectors"))
-	viper.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
-	viper.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
-	viper.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))
-	viper.BindPFlag("host_monitoring::logs::include", cmd.PersistentFlags().Lookup("host_monitoring::logs::include"))
-	viper.BindPFlag("host_monitoring::metrics::host::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::host::enabled"))
-	viper.BindPFlag("host_monitoring::metrics::process::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::process::enabled"))
+	v.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
+	v.BindPFlag("observe_url", cmd.PersistentFlags().Lookup("observe_url"))
+	v.BindPFlag("cloud_resource_detectors", cmd.PersistentFlags().Lookup("cloud_resource_detectors"))
+	v.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
+	v.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
+	v.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))
+	v.BindPFlag("host_monitoring::logs::include", cmd.PersistentFlags().Lookup("host_monitoring::logs::include"))
+	v.BindPFlag("host_monitoring::metrics::host::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::host::enabled"))
+	v.BindPFlag("host_monitoring::metrics::process::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::process::enabled"))
 }

--- a/internal/commands/initconfig/initconfig.go
+++ b/internal/commands/initconfig/initconfig.go
@@ -18,6 +18,7 @@ var (
 	config_path                             string
 	token                                   string
 	observe_url                             string
+	cloud_resource_detectors                []string
 	self_monitoring_enabled                 bool
 	host_monitoring_enabled                 bool
 	host_monitoring_logs_enabled            bool
@@ -33,6 +34,7 @@ const configTemplate = "observe-agent.tmpl"
 type FlatAgentConfig struct {
 	Token                                 string
 	ObserveURL                            string
+	CloudResourceDetectors                []string
 	SelfMonitoring_Enabled                bool
 	HostMonitoring_Enabled                bool
 	HostMonitoring_LogsEnabled            bool
@@ -50,6 +52,7 @@ func NewConfigureCmd() *cobra.Command {
 			configValues := FlatAgentConfig{
 				Token:                                 viper.GetString("token"),
 				ObserveURL:                            viper.GetString("observe_url"),
+				CloudResourceDetectors:                viper.GetStringSlice("cloud_resource_detectors"),
 				SelfMonitoring_Enabled:                viper.GetBool("self_monitoring::enabled"),
 				HostMonitoring_Enabled:                viper.GetBool("host_monitoring::enabled"),
 				HostMonitoring_LogsEnabled:            viper.GetBool("host_monitoring::logs::enabled"),
@@ -90,6 +93,7 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&config_path, "config_path", "", "", "Path to write config output file to")
 	cmd.PersistentFlags().StringVar(&token, "token", "", "Observe token")
 	cmd.PersistentFlags().StringVar(&observe_url, "observe_url", "", "Observe data collection url")
+	cmd.PersistentFlags().StringSliceVar(&cloud_resource_detectors, "cloud_resource_detectors", []string{}, "Cloud resource detectors")
 	cmd.PersistentFlags().BoolVar(&self_monitoring_enabled, "self_monitoring::enabled", true, "Enable self monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_enabled, "host_monitoring::enabled", true, "Enable host monitoring")
 	cmd.PersistentFlags().BoolVar(&host_monitoring_logs_enabled, "host_monitoring::logs::enabled", true, "Enable host monitoring logs")
@@ -98,6 +102,7 @@ func RegisterConfigFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_process_enabled, "host_monitoring::metrics::process::enabled", false, "Enable host monitoring process metrics")
 	viper.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
 	viper.BindPFlag("observe_url", cmd.PersistentFlags().Lookup("observe_url"))
+	viper.BindPFlag("cloud_resource_detectors", cmd.PersistentFlags().Lookup("cloud_resource_detectors"))
 	viper.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
 	viper.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))

--- a/internal/commands/initconfig/initconfig_test.go
+++ b/internal/commands/initconfig/initconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/observeinc/observe-agent/internal/config"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
@@ -67,8 +68,9 @@ func Test_InitConfigCommand(t *testing.T) {
 			expectErr: "",
 		},
 	}
-	initConfigCmd := NewConfigureCmd()
-	RegisterConfigFlags(initConfigCmd)
+	v := viper.New()
+	initConfigCmd := NewConfigureCmd(v)
+	RegisterConfigFlags(initConfigCmd, v)
 	for _, tc := range testcases {
 		initConfigCmd.SetArgs(tc.args)
 		err := initConfigCmd.Execute()

--- a/internal/commands/initconfig/observe-agent.tmpl
+++ b/internal/commands/initconfig/observe-agent.tmpl
@@ -7,6 +7,13 @@ observe_url: {{ .ObserveURL }}
 # Debug mode - Sets agent log level to debug
 debug: false
 
+{{ if .CloudResourceDetectors -}}
+cloud_resource_detectors:
+{{- range .CloudResourceDetectors }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+
 self_monitoring:
   enabled: {{ .SelfMonitoring_Enabled }}
 

--- a/internal/connections/templatefuncs.go
+++ b/internal/connections/templatefuncs.go
@@ -22,7 +22,7 @@ func TplInlineArray[T any](arr []T) string {
 	for i := range arr {
 		strs[i] = TmplValueToYaml(arr[i])
 	}
-	return "[" + strings.Join(strs, ",") + "]"
+	return "[" + strings.Join(strs, ", ") + "]"
 }
 
 func TmplValueToYaml(value any) string {

--- a/internal/connections/templatefuncs_test.go
+++ b/internal/connections/templatefuncs_test.go
@@ -16,13 +16,13 @@ func TestTmplValueToYaml(t *testing.T) {
 
 func TestTplInlineArray(t *testing.T) {
 	strSlice := []string{"a", "b", "c", "y"}
-	assert.Equal(t, "[a,b,c,\"y\"]", TplInlineArray(strSlice))
+	assert.Equal(t, "[a, b, c, \"y\"]", TplInlineArray(strSlice))
 
 	intSlice := []int{1, 2, 3}
-	assert.Equal(t, "[1,2,3]", TplInlineArray(intSlice))
+	assert.Equal(t, "[1, 2, 3]", TplInlineArray(intSlice))
 
 	strIntSlice := []any{"a", 1, "b", 2}
-	assert.Equal(t, "[a,1,b,2]", TplInlineArray(strIntSlice))
+	assert.Equal(t, "[a, 1, b, 2]", TplInlineArray(strIntSlice))
 }
 
 func TestTplToYaml(t *testing.T) {

--- a/internal/connections/test/testHelloWorld.yaml
+++ b/internal/connections/test/testHelloWorld.yaml
@@ -1,5 +1,5 @@
 string: hello world
-in-line-array: [1,2,3]
+in-line-array: [1, 2, 3]
 multi-line-array:
   - 4
   - 5

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -69,7 +69,7 @@ processors:
   resourcedetection/cloud:
     detectors:
     {{- if .CloudResourceDetectors }}
-    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- " " }}{{ inlineArrayStr .CloudResourceDetectors }}
     {{- else }} ["gcp", "ecs", "ec2", "azure"]
     {{- end }}
     timeout: 2s

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -69,7 +69,7 @@ processors:
   resourcedetection/cloud:
     detectors:
     {{- if .CloudResourceDetectors }}
-    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- " " }}{{ inlineArrayStr .CloudResourceDetectors }}
     {{- else }} ["gcp", "ecs", "ec2", "azure"]
     {{- end }}
     timeout: 2s

--- a/packaging/macos/config/otel-collector.yaml
+++ b/packaging/macos/config/otel-collector.yaml
@@ -69,7 +69,7 @@ processors:
   resourcedetection/cloud:
     detectors:
     {{- if .CloudResourceDetectors }}
-    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- " " }}{{ inlineArrayStr .CloudResourceDetectors }}
     {{- else }} ["gcp", "ecs", "ec2", "azure"]
     {{- end }}
     timeout: 2s

--- a/packaging/windows/config/otel-collector.yaml
+++ b/packaging/windows/config/otel-collector.yaml
@@ -49,7 +49,7 @@ processors:
   resourcedetection/cloud:
     detectors:
     {{- if .CloudResourceDetectors }}
-    {{- inlineArrayStr .CloudResourceDetectors }}
+    {{- " " }}{{ inlineArrayStr .CloudResourceDetectors }}
     {{- else }} ["gcp", "ecs", "ec2", "azure"]
     {{- end }}
     timeout: 2s


### PR DESCRIPTION
### Description

fix whitespace typo when customizing CloudResourceDetectors. Before this change, the generated config was `detectors:[ec2]` instead of `detectors: [ec2]`

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary