### PR TITLE
feat: add env var example to docker-compose, add agent config to image

### DIFF
--- a/packaging/docker/compose-linux-host.yaml
+++ b/packaging/docker/compose-linux-host.yaml
@@ -2,6 +2,10 @@ services:
   agent:
     image: "observeinc/observe-agent:latest"
     pid: host
+    # Optionally use environment variables to configure the agent.
+    # environment:
+    #   - TOKEN=${TOKEN}
+    #   - OBSERVE_URL=${OBSERVE_URL}
     volumes:
       # Used for hostmetrics
       - type: bind
@@ -29,7 +33,7 @@ services:
       - type: bind
         source: /var/lib/docker/containers
         target: /var/lib/docker/containers
-      # Load agent from current directory
+      # Optionally load agent config from current directory.
       - type: bind
         source: ${PWD}/observe-agent.yaml
         target: /etc/observe-agent/observe-agent.yaml

--- a/packaging/docker/observe-agent/observe-agent.yaml
+++ b/packaging/docker/observe-agent/observe-agent.yaml
@@ -1,0 +1,13 @@
+# A minimal default agent config which should be overwritten via a docker volume or environment variables.
+debug: false
+self_monitoring:
+  enabled: true
+host_monitoring:
+  enabled: true
+  logs:
+    enabled: true
+  metrics:
+    host:
+      enabled: true
+    process:
+      enabled: false


### PR DESCRIPTION
### Description

Add env var example to docker-compose, add agent config to image.
The goal of this change is to make Docker usage more clear.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary