### PR TITLE
fix: clarify and expand the default env vars the agent provides to the configs

### DIFF
--- a/internal/connections/confighandler.go
+++ b/internal/connections/confighandler.go
@@ -78,13 +78,19 @@ func GetAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, er
 
 func SetEnvVars() error {
 	collector_url, token, debug := viper.GetString("observe_url"), viper.GetString("token"), viper.GetBool("debug")
-	endpoint, err := url.JoinPath(collector_url, "/v2/otel")
+	otelEndpoint, err := url.JoinPath(collector_url, "/v2/otel")
+	if err != nil {
+		return err
+	}
+	promEndpoint, err := url.JoinPath(collector_url, "/v1/prometheus")
 	if err != nil {
 		return err
 	}
 	// Setting values from the Observe agent config as env vars to fill in the OTEL collector config
-	os.Setenv("OBSERVE_ENDPOINT", endpoint)
-	os.Setenv("OBSERVE_TOKEN", "Bearer "+token)
+	os.Setenv("OBSERVE_COLLECTOR_URL", collector_url)
+	os.Setenv("OBSERVE_OTEL_ENDPOINT", otelEndpoint)
+	os.Setenv("OBSERVE_PROMETHEUS_ENDPOINT", promEndpoint)
+	os.Setenv("OBSERVE_AUTHORIZATION_HEADER", "Bearer "+token)
 	os.Setenv("FILESTORAGE_PATH", GetDefaultFilestoragePath())
 
 	if debug {

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -83,9 +83,9 @@ processors:
 
 exporters:
   otlphttp/observe:
-    endpoint: ${env:OBSERVE_ENDPOINT}
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
-      authorization: ${env:OBSERVE_TOKEN}
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
     sending_queue:
       num_consumers: 4
       queue_size: 100

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -83,9 +83,9 @@ processors:
 
 exporters:
   otlphttp/observe:
-    endpoint: ${env:OBSERVE_ENDPOINT}
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
-      authorization: ${env:OBSERVE_TOKEN}
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
     sending_queue:
       num_consumers: 4
       queue_size: 100

--- a/packaging/macos/config/otel-collector.yaml
+++ b/packaging/macos/config/otel-collector.yaml
@@ -83,9 +83,9 @@ processors:
 
 exporters:
   otlphttp/observe:
-    endpoint: ${env:OBSERVE_ENDPOINT}
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
-      authorization: ${env:OBSERVE_TOKEN}
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
     sending_queue:
       num_consumers: 4
       queue_size: 100

--- a/packaging/windows/config/otel-collector.yaml
+++ b/packaging/windows/config/otel-collector.yaml
@@ -63,9 +63,9 @@ processors:
 
 exporters:
   otlphttp/observe:
-    endpoint: ${env:OBSERVE_ENDPOINT}
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
-      authorization: ${env:OBSERVE_TOKEN}
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
     sending_queue:
       num_consumers: 4
       queue_size: 100


### PR DESCRIPTION
### Description

Clarify and expand the default env vars the agent provides to the configs. This makes the vanilla collector endpoint available as well as exposing the prometheus endpoint. It also renames OBSERVE_TOKEN to OBSERVE_AUTHORIZATION_HEADER for clarity since the value is prefixed by `"Bearer "`, and renames OBSERVE_ENDPOINT to OBSERVE_OTEL_ENDPOINT since the value is suffixed with `"/v2/otel"` 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary