### PR TITLE
fix: update linux install to match mac install args

### DIFF
--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -6,6 +6,38 @@ agent_binary_path="/usr/bin/observe-agent"
 observeagent_config_dir="/etc/observe-agent"
 tmp_dir="/tmp/observe-agent"
 
+# Parse args
+while [ $# -gt 0 ]; do
+    opt=$1
+    shift
+    arg=""
+    if [[ "$opt" == *"="* ]]; then
+        arg=$(echo $opt | cut -d'=' -f2)
+        opt=$(echo $opt | cut -d'=' -f1)
+    elif [ $# -gt 0 ]; then
+        arg="$1"
+        shift
+    fi
+    case "$opt" in
+        --token)
+            TOKEN="$arg"
+            ;;
+        --observe_url)
+            OBSERVE_URL="$arg"
+            ;;
+        --logs_enabled)
+            LOGS_ENABLED="$arg"
+            ;;
+        --metrics_enabled)
+            METRICS_ENABLED="$arg"
+            ;;
+        *)
+            echo "Unknown option: $opt"
+            exit 1
+            ;;
+    esac
+done
+
 # If the observe-agent.yaml file already exists, leave it alone.
 # Otherwise we need to know what the collection endpoint and token are.
 if [ ! -f "$observeagent_config_dir/observe-agent.yaml" ]; then
@@ -48,26 +80,44 @@ sudo rm -rf $observeagent_config_dir/connections
 sudo cp -fR $tmp_dir/connections $observeagent_config_dir/connections
 sudo chown -R root:root $observeagent_config_dir
 
-# Set up the systemd service if it doesn't exist already.
-if ! systemctl list-unit-files observe-agent.service | grep observe-agent >/dev/null; then
-    echo "Installing observe-agent.service as a systemd service. This may ask for your password..."
-    sudo cp -f $tmp_dir/observe-agent.service /etc/systemd/system/observe-agent.service
-    sudo chown root:root /etc/systemd/system/observe-agent.service
-    sudo systemctl daemon-reload
-    sudo systemctl enable observe-agent.service
-    sudo systemctl start observe-agent
-elif systemctl is-active --quiet observe-agent; then
-    echo "Restarting observe-agent.service. This may ask for your password..."
-    sudo systemctl restart observe-agent
-fi
-
 # Initialize the agent config file if it doesn't exist.
 if [ -f "$observeagent_config_dir/observe-agent.yaml" ]; then
     echo "Leaving existing observe-agent.yaml in place."
 else
     echo "Initializing observe-agent.yaml"
-    sudo $agent_binary_path init-config --token $TOKEN --observe_url $OBSERVE_URL --config_path $observeagent_config_dir/observe-agent.yaml
+    INIT_FLAGS="--config_path $observeagent_config_dir/observe-agent.yaml --token $TOKEN --observe_url $OBSERVE_URL --host_monitoring::enabled=true"
+    if [ -n "$LOGS_ENABLED" ]; then
+        if [[ "${LOGS_ENABLED,,}" == "true" ]]; then
+            INIT_FLAGS="$INIT_FLAGS --host_monitoring::logs::enabled=true"
+        else
+            INIT_FLAGS="$INIT_FLAGS --host_monitoring::logs::enabled=false"
+        fi
+    fi
+    if [ -n "$METRICS_ENABLED" ]; then
+        if [[ "${METRICS_ENABLED,,}" == "true" ]]; then
+            INIT_FLAGS="$INIT_FLAGS --host_monitoring::metrics::host::enabled=true"
+        else
+            INIT_FLAGS="$INIT_FLAGS --host_monitoring::metrics::host::enabled=false"
+        fi
+    fi
+    sudo $agent_binary_path init-config $INIT_FLAGS
     sudo chown root:root $observeagent_config_dir/observe-agent.yaml
+fi
+
+# Check if systemd is available.
+if [[ -d /run/systemd/system ]]; then
+    # Set up the systemd service if it doesn't exist already.
+    if ! systemctl list-unit-files observe-agent.service | grep observe-agent >/dev/null; then
+        echo "Installing observe-agent.service as a systemd service. This may ask for your password..."
+        sudo cp -f $tmp_dir/observe-agent.service /etc/systemd/system/observe-agent.service
+        sudo chown root:root /etc/systemd/system/observe-agent.service
+        sudo systemctl daemon-reload
+        sudo systemctl enable observe-agent.service
+        sudo systemctl start observe-agent
+    elif systemctl is-active --quiet observe-agent; then
+        echo "Restarting observe-agent.service. This may ask for your password..."
+        sudo systemctl restart observe-agent
+    fi
 fi
 
 echo "Observe agent successfully installed to $agent_binary_path with config in $observeagent_config_dir"


### PR DESCRIPTION
### Description

Update linux install to match mac install args. Also only run the `systemd` setup when `systemd` is available.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary