### PR TITLE
fix: remove old bundled config files in mac install upgrade

### DIFF
--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -78,9 +78,10 @@ sudo mkdir -p $observeagent_install_dir /usr/local/libexec /usr/local/bin /var/l
 sudo chmod +rw /var/lib/observe-agent/filestorage
 
 # Copy all files to the install dir.
-sudo cp -f $tmp_dir/observe-agent $observeagent_install_dir/observe-agent
-sudo cp -fR $tmp_dir/config $observeagent_install_dir/config
-sudo cp -fR $tmp_dir/connections $observeagent_install_dir/connections
+sudo rm -rf $observeagent_install_dir/config $observeagent_install_dir/connections $observeagent_install_dir/observe-agent
+sudo cp $tmp_dir/observe-agent $observeagent_install_dir/observe-agent
+sudo cp -R $tmp_dir/config $observeagent_install_dir/config
+sudo cp -R $tmp_dir/connections $observeagent_install_dir/connections
 sudo chown -R root:wheel $observeagent_install_dir
 
 # Initialize the agent config file if it doesn't exist


### PR DESCRIPTION
### Description

Remove old bundled config files in mac install upgrade. I thought `cp -fR` would be sufficient, but that's not the case! I wasn't able to understand why the functionality is how it is, but here's a simple example to show the issue:
```sh
$ mkdir a && echo hello > a/test.txt && cp -R a b && cat b/test.txt
hello

$ echo goodbye > a/test.txt && cp -fR a b && cat b/test.txt 
hello

$ cat a/test.txt 
goodbye
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary