### PR TITLE
feat: add exclude config option for excluding host log files

### DIFF
--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -12,6 +12,7 @@ import (
 type HostMonitoringLogsConfig struct {
 	Enabled bool     `yaml:"enabled" mapstructure:"enabled"`
 	Include []string `yaml:"include,omitempty" mapstructure:"include"`
+	Exclude []string `yaml:"exclude,omitempty" mapstructure:"exclude"`
 }
 
 type HostMonitoringHostMetricsConfig struct {

--- a/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml
@@ -9,6 +9,12 @@ receivers:
       - /hostfs/var/log/**/*.log
       - /hostfs/var/log/syslog
       {{- end }}
+    {{- if .Logs.Exclude }}
+    exclude:
+      {{- range .Logs.Exclude }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:

--- a/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
+++ b/packaging/linux/etc/observe-agent/connections/host_monitoring/logs.yaml
@@ -9,6 +9,12 @@ receivers:
       - /var/log/**/*.log
       - /var/log/syslog
       {{- end }}
+    {{- if .Logs.Exclude }}
+    exclude:
+      {{- range .Logs.Exclude }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:

--- a/packaging/macos/connections/host_monitoring/logs.yaml
+++ b/packaging/macos/connections/host_monitoring/logs.yaml
@@ -1,6 +1,19 @@
 receivers:
   filelog/host_monitoring:
-    include: [/var/log/**/*.log]
+    include:
+      {{- if .Logs.Include }}
+      {{- range .Logs.Include }}
+      - {{ . }}
+      {{- end }}
+      {{- else }}
+      - /var/log/**/*.log
+      {{- end }}
+    {{- if .Logs.Exclude }}
+    exclude:
+      {{- range .Logs.Exclude }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
     include_file_path: true
     storage: file_storage
     retry_on_failure:

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -31,6 +31,9 @@ while [ $# -gt 0 ]; do
         --metrics_enabled)
             METRICS_ENABLED="$arg"
             ;;
+        --setup_launch_daemon)
+            SETUP_LAUNCH_DAEMON="$arg"
+            ;;
         *)
             echo "Unknown option: $opt"
             exit 1
@@ -114,12 +117,14 @@ sudo ln -sf $observeagent_install_dir/observe-agent /usr/local/bin
 
 echo "Observe agent successfully installed to $observeagent_install_dir"
 
-# Install the launchd agent
-echo "Installing $service_name as a LaunchDaemon. This may ask for your password..."
-sudo cp -f $tmp_dir/observe-agent.plist /Library/LaunchDaemons/$service_name.plist
-sudo chown root:wheel /Library/LaunchDaemons/$service_name.plist
-sudo launchctl load -w /Library/LaunchDaemons/$service_name.plist
-sudo launchctl kickstart "system/$service_name"
+# Install the launchd agent unless the variable is specified to false
+if [ -z "$SETUP_LAUNCH_DAEMON" ] || [[ "$(echo "$SETUP_LAUNCH_DAEMON" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+    echo "Installing $service_name as a LaunchDaemon. This may ask for your password..."
+    sudo cp -f $tmp_dir/observe-agent.plist /Library/LaunchDaemons/$service_name.plist
+    sudo chown root:wheel /Library/LaunchDaemons/$service_name.plist
+    sudo launchctl load -w /Library/LaunchDaemons/$service_name.plist
+    sudo launchctl kickstart "system/$service_name"
+fi
 
 echo
 echo "---"


### PR DESCRIPTION
### Description

OB-40414 Add exclude config option for excluding host log files.

Excerpt from `observe-agent config`:
```yml
# $ cat /usr/local/observe-agent/observe-agent.yaml 
# ...
host_monitoring:
  enabled: true
  logs:
    enabled: true
    exclude: [asdf.txt]

# $ observe-agent config
# ...
# ======== config file /var/folders/y8/v7cyk9611qbg059c0q02vk0w0000gn/T/observe-agent1962015451/2697844591-logs.yaml
receivers:
  filelog/host_monitoring:
    include:
      - /var/log/**/*.log
    exclude:
      - asdf.txt
    include_file_path: true
    storage: file_storage
    retry_on_failure:
      enabled: true
    max_log_size: 4MiB
    operators:
      - type: filter
        expr: 'body matches "otel-contrib"'
```



### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary