### PR TITLE
feat: add optional version arg to install scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,11 +1,16 @@
 param (
     [Parameter()]
-    $observe_collection_endpoint, 
+    [String]$version,
     [Parameter()]
-    $observe_token
+    [String]$observe_collection_endpoint,
+    [Parameter()]
+    [String]$observe_token
 )
 
 $installer_url="https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Windows_x86_64.zip"
+if ($PSBoundParameters.ContainsKey('version')){
+    $installer_url="https://github.com/observeinc/observe-agent/releases/download/v$version/observe-agent_Windows_x86_64.zip"
+}
 $local_installer="C:\temp\observe-agent_Windows_x86_64.zip"
 $program_data_filestorage="C:\ProgramData\Observe\observe-agent\filestorage"
 $observeagent_install_dir="$env:ProgramFiles\Observe\observe-agent"
@@ -59,7 +64,7 @@ if(-not (Get-Service ObserveAgent -ErrorAction SilentlyContinue)){
         StartupType = "Automatic"
         Description = "Observe Agent based on OpenTelemetry collector"
       }
-      
+
     New-Service @params
     Start-Service ObserveAgent
     }

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -31,6 +31,12 @@ while [ $# -gt 0 ]; do
         --metrics_enabled)
             METRICS_ENABLED="$arg"
             ;;
+        --version)
+            AGENT_VERSION="$arg"
+            ;;
+        --zip_dir)
+            ZIP_DIR="$arg"
+            ;;
         *)
             echo "Unknown option: $opt"
             exit 1
@@ -54,10 +60,19 @@ fi
 
 # If the zip file is not provided, download the latest release from GitHub.
 if [ -z "$ZIP_DIR" ]; then
-    echo "Downloading latest release from GitHub..."
-    curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Linux_$(arch).tar.gz
+    if [ -n "$AGENT_VERSION" ]; then
+        echo "Downloading version $AGENT_VERSION from GitHub..."
+        curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/download/v$AGENT_VERSION/observe-agent_Linux_$(arch).tar.gz
+    else
+        echo "Downloading latest release from GitHub..."
+        curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Linux_$(arch).tar.gz
+    fi
     ZIP_DIR="/tmp/observe-agent.tar.gz"
 else
+    if [ -n "$AGENT_VERSION" ]; then
+        echo "Cannot specify both ZIP_DIR ($ZIP_DIR) and AGENT_VERSION ($AGENT_VERSION)"
+        exit 1
+    fi
     echo "Installing from provided zip file: $ZIP_DIR"
 fi
 

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -34,6 +34,12 @@ while [ $# -gt 0 ]; do
         --setup_launch_daemon)
             SETUP_LAUNCH_DAEMON="$arg"
             ;;
+        --version)
+            AGENT_VERSION="$arg"
+            ;;
+        --zip_dir)
+            ZIP_DIR="$arg"
+            ;;
         *)
             echo "Unknown option: $opt"
             exit 1
@@ -57,10 +63,19 @@ fi
 
 # If the zip file is not provided, download the latest release from GitHub.
 if [ -z "$ZIP_DIR" ]; then
-    echo "Downloading latest release from GitHub..."
-    curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Darwin_$(arch).zip
+    if [ -n "$AGENT_VERSION" ]; then
+        echo "Downloading version $AGENT_VERSION from GitHub..."
+        curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/download/v$AGENT_VERSION/observe-agent_Darwin_$(arch).zip
+    else
+        echo "Downloading latest release from GitHub..."
+        curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Darwin_$(arch).zip
+    fi
     ZIP_DIR="/tmp/observe-agent.zip"
 else
+    if [ -n "$AGENT_VERSION" ]; then
+        echo "Cannot specify both ZIP_DIR ($ZIP_DIR) and AGENT_VERSION ($AGENT_VERSION)"
+        exit 1
+    fi
     echo "Installing from provided zip file: $ZIP_DIR"
 fi
 


### PR DESCRIPTION
### Description

OB-40308 add optional version arg to install scripts. This will allow our old Host Quickstart app installation instructions to be pinned to an older version as we update the agent.

Example usage:
```
PS C:\Users\Administrator\Downloads> .\install.ps1 -version 1.4.0

PS C:\Users\Administrator\Downloads> & 'C:\Program Files\Observe\observe-agent\observe-agent.exe' version
Using config file: C:\Program Files\Observe\observe-agent\observe-agent.yaml
observe-agent version: 1.4.0
```

```
$ bash ./scripts/install_mac.sh --version 1.5.0
Downloading version 1.5.0 from GitHub...
# ...

$ observe-agent version
observe-agent version: 1.5.0
observe-agent config file: /usr/local/observe-agent/observe-agent.yaml
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary