### PR TITLE
fix: add file path to filelog/agent-config receiver

### DIFF
--- a/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
@@ -1,6 +1,7 @@
 receivers:
   filelog/agent-config: # TODO: Add observe-agent.yaml once we can obfuscate sensitive config fields
     include: [/etc/observe-agent/otel-collector.yaml]
+    include_file_path: true
     start_at: beginning
     poll_interval: 5m
     multiline:

--- a/packaging/linux/etc/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/linux/etc/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
@@ -1,6 +1,7 @@
 receivers:
   filelog/agent-config: # TODO: Add observe-agent.yaml once we can obfuscate sensitive config fields
     include: [/etc/observe-agent/otel-collector.yaml]
+    include_file_path: true
     start_at: beginning
     poll_interval: 5m
     multiline:

--- a/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
@@ -1,6 +1,7 @@
 receivers:
   filelog/agent-config: # TODO: Add observe-agent.yaml once we can obfuscate sensitive config fields
     include: [/usr/local/observe-agent/config/otel-collector.yaml]
+    include_file_path: true
     start_at: beginning
     poll_interval: 5m
     multiline:

--- a/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml
@@ -1,6 +1,7 @@
 receivers:
   filelog/agent-config: # TODO: Add observe-agent.yaml once we can obfuscate sensitive config fields
     include: ['C:\Program Files\Observe\observe-agent\config\otel-collector.yaml']
+    include_file_path: true
     start_at: beginning
     poll_interval: 5m
     multiline:


### PR DESCRIPTION
### Description

Add file path to filelog/agent-config receiver. Our provided content extracts this field as a separate column, so we should set this attribute in all provided receivers.
