### PR TITLE
fix: always put deltatocumulative processor before batch processor

### DIFF
--- a/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
@@ -27,7 +27,7 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-journald:

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -109,7 +109,7 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:

--- a/packaging/linux/etc/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/linux/etc/observe-agent/connections/self_monitoring/logs_and_metrics.yaml
@@ -27,7 +27,7 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-journald:

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -109,7 +109,7 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:

--- a/packaging/macos/config/otel-collector.yaml
+++ b/packaging/macos/config/otel-collector.yaml
@@ -109,7 +109,7 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:

--- a/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
@@ -22,7 +22,7 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-config:

--- a/packaging/windows/config/otel-collector.yaml
+++ b/packaging/windows/config/otel-collector.yaml
@@ -89,7 +89,7 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:

--- a/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml
@@ -22,7 +22,7 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch, deltatocumulative]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-config:


### PR DESCRIPTION
### Description

Always put deltatocumulative processor before batch processor to keep batching as the last step.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary