### PR TITLE
fix: clean up spacing for diagnose and status output, move status to end of output

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: 2.7.0
-          args: release --prepare --clean --snapshot --verbose --parallelism 8
+          args: release --prepare --clean --snapshot --verbose --parallelism 6
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: Save docker as .tar #Save docker images to tar

--- a/internal/commands/diagnose/authcheck.tmpl
+++ b/internal/commands/diagnose/authcheck.tmpl
@@ -1,12 +1,12 @@
 Running auth check against {{ .URL }}
 
-{{- if .Passed -}}
+{{- if .Passed }}
 Request to test URL responded with response code {{ .ResponseCode }}
-{{- else if eq .ResponseCode 401 -}}
+{{- else if eq .ResponseCode 401 }}
 ⚠️ Request to test URL failed with error {{ .Error }}.
 
 Remediation
 Please check that the token is present in the `observe-agent.yaml` config file and that the token is valid. 
-{{- else -}}
+{{- else }}
 ⚠️ Request to test URL failed with error {{ .Error }} and response code {{ .ResponseCode }}.
 {{- end -}}

--- a/internal/commands/diagnose/configcheck.tmpl
+++ b/internal/commands/diagnose/configcheck.tmpl
@@ -1,10 +1,10 @@
 Running check on observe-agent config file {{ .ConfigFile }}
 
-{{- if .IsValid -}}
+{{- if .IsValid }}
 Config file is valid.
-{{- else if .ParseSucceeded -}}
+{{- else if .ParseSucceeded }}
 ⚠️ Config file validation failed with error {{ .Error }}
-{{- else -}}
+{{- else }}
 ⚠️ Config file could not be parsed as YAML
 {{ .Error }}
 {{- end -}}

--- a/internal/commands/diagnose/otelconfigcheck.tmpl
+++ b/internal/commands/diagnose/otelconfigcheck.tmpl
@@ -1,5 +1,6 @@
 {{- if .Passed -}}
 OTEL configuration is valid.
 {{- else -}}
-⚠️ OTEL configuration validation failed with error {{ .Error }}
+⚠️ OTEL configuration validation failed with error:
+{{ .Error }}
 {{- end -}}

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"os"
 
+	"github.com/observeinc/observe-agent/internal/connections"
 	"github.com/observeinc/observe-agent/internal/root"
 	"github.com/spf13/cobra"
 )
@@ -31,16 +32,6 @@ var statusCmd = &cobra.Command{
 
 func init() {
 	root.RootCmd.AddCommand(statusCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// statusCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// statusCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 func getStatusFromTemplate() error {
@@ -48,7 +39,9 @@ func getStatusFromTemplate() error {
 	if err != nil {
 		return err
 	}
-	t := template.Must(template.New(statusTemplate).ParseFS(statusTemplateFS, statusTemplate))
+	t := template.Must(template.New(statusTemplate).
+		Funcs(connections.GetTemplateFuncMap()).
+		ParseFS(statusTemplateFS, statusTemplate))
 	if err := t.ExecuteTemplate(os.Stdout, statusTemplate, data); err != nil {
 		return err
 	}

--- a/internal/commands/status/status.tmpl
+++ b/internal/commands/status/status.tmpl
@@ -1,24 +1,22 @@
 ================
-Agent 
+Agent
 ================
 
-  Status: {{ .Status }}
- 
-  Host Info 
-  ================ 
+  Host Info
+  ================
   HostID: {{ .HostID }}
   Hostname: {{ .Hostname }}
   BootTime: {{ .BootTime }}
-  Uptime: {{ .UpTime }} 
+  Uptime: {{ .UpTime }}
   OS: {{ .OS }}
   Platform: {{ .Platform }}
   PlatformFamily: {{ .PlatformFamily }}
   PlatformVersion: {{ .PlatformVersion }}
   KernelArch: {{ .KernelArch }}
   KernelVersion: {{ .KernelVersion }}
+{{- if eq .Status "Running" }}
 
-  {{if eq .Status "Running"}}
-  Agent Metrics 
+  Agent Metrics
   ================
   ExporterQueueSize: {{ .AgentMetrics.ExporterQueueSize }}
   CPUSeconds: {{ .AgentMetrics.CPUSeconds }}s
@@ -27,25 +25,33 @@ Agent
   Uptime: {{ .AgentMetrics.Uptime }}s
   AvgServerResponseTime: {{ .AgentMetrics.AvgServerResponseTime }}ms
   AvgClientResponseTime: {{ .AgentMetrics.AvgClientResponseTime }}ms
-      
+
     Logs Stats
-    ===============
+    ================
     ReceiverAcceptedCount: {{ .AgentMetrics.LogsStats.ReceiverAcceptedCount }}
     ReceiverRefusedCount: {{ .AgentMetrics.LogsStats.ReceiverRefusedCount }}
     ExporterSentCount: {{ .AgentMetrics.LogsStats.ExporterSentCount }}
     ExporterSendFailedCount: {{ .AgentMetrics.LogsStats.ExporterSendFailedCount }}
-    
+
     Metrics Stats
-    ===============
+    ================
     ReceiverAcceptedCount: {{ .AgentMetrics.MetricsStats.ReceiverAcceptedCount }}
     ReceiverRefusedCount: {{ .AgentMetrics.MetricsStats.ReceiverRefusedCount }}
     ExporterSentCount: {{ .AgentMetrics.MetricsStats.ExporterSentCount }}
     ExporterSendFailedCount: {{ .AgentMetrics.MetricsStats.ExporterSendFailedCount }}
-  
+
     Traces Stats
-    ===============
+    ================
     ReceiverAcceptedCount: {{ .AgentMetrics.TracesStats.ReceiverAcceptedCount }}
     ReceiverRefusedCount: {{ .AgentMetrics.TracesStats.ReceiverRefusedCount }}
     ExporterSentCount: {{ .AgentMetrics.TracesStats.ExporterSentCount }}
     ExporterSendFailedCount: {{ .AgentMetrics.TracesStats.ExporterSendFailedCount }}
-{{end -}}
+{{- end }}
+
+  Agent Health
+  ================
+  Status: {{ .Status }}
+  {{- if eq .Status "Running" }}
+  TotalRefusedCount: {{ add .AgentMetrics.LogsStats.ReceiverRefusedCount .AgentMetrics.MetricsStats.ReceiverRefusedCount .AgentMetrics.TracesStats.ReceiverRefusedCount }}
+  TotalSendFailedCount: {{ add .AgentMetrics.LogsStats.ExporterSendFailedCount .AgentMetrics.MetricsStats.ExporterSendFailedCount .AgentMetrics.TracesStats.ExporterSendFailedCount }}
+  {{- end }}

--- a/internal/connections/templatefuncs.go
+++ b/internal/connections/templatefuncs.go
@@ -14,6 +14,13 @@ func GetTemplateFuncMap() template.FuncMap {
 		"inlineArrayStr": TplInlineArray[string],
 		"valToYaml":      TmplValueToYaml,
 		"objToYaml":      TplToYaml,
+		"add": func(values ...int) int {
+			sum := 0
+			for _, i := range values {
+				sum += i
+			}
+			return sum
+		},
 	}
 }
 


### PR DESCRIPTION
### Description

Clean up spacing for diagnose and status output, move status to end of output.

Ex:
```
$ ./observe-agent status
Error getting agent metrics:  Get "http://localhost:8888/metrics": dial tcp 127.0.0.1:8888: connect: connection refused
================
Agent
================

  Host Info
  ================
  HostID: ...
  Hostname: ...
  BootTime: 2025-02-25T22:47:39-06:00
  Uptime: 206h22m21s
  OS: darwin
  Platform: darwin
  PlatformFamily: Standalone Workstation
  PlatformVersion: 15.3.1
  KernelArch: arm64
  KernelVersion: 24.3.0

  Agent Health
  ================
  Status: NotRunning

```
or
```
$ ./observe-agent status
================
Agent
================

  Host Info
  ================
  HostID: ...
  Hostname: ...
  BootTime: 2025-02-25T22:47:39-06:00
  Uptime: 206h25m34s
  OS: darwin
  Platform: darwin
  PlatformFamily: Standalone Workstation
  PlatformVersion: 15.3.1
  KernelArch: arm64
  KernelVersion: 24.3.0

  Agent Metrics
  ================
  ExporterQueueSize: 0
  CPUSeconds: 0.15447955s
  MemoryUsed: 82.5625MB
  TotalSysMemory: 27.891853MB
  Uptime: 7.477466s
  AvgServerResponseTime: 0ms
  AvgClientResponseTime: 0ms

    Logs Stats
    ================
    ReceiverAcceptedCount: 0
    ReceiverRefusedCount: 0
    ExporterSentCount: 0
    ExporterSendFailedCount: 0

    Metrics Stats
    ================
    ReceiverAcceptedCount: 0
    ReceiverRefusedCount: 0
    ExporterSentCount: 0
    ExporterSendFailedCount: 0

    Traces Stats
    ================
    ReceiverAcceptedCount: 0
    ReceiverRefusedCount: 0
    ExporterSentCount: 0
    ExporterSendFailedCount: 0

  Agent Health
  ================
  Status: Running
  TotalRefusedCount: 0
  TotalSendFailedCount: 0
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary