### PR TITLE
feat: upgrade go version to 1.22.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code for the Observe agent and CLI. The agent code is based on the OpenTelemetry
 
 # Build
 
-To run the code you need to have `golang v1.22.7` installed. Then you can run the following command to compile the binary.
+To run the code you need to have `golang v1.22.8` installed. Then you can run the following command to compile the binary.
 
 ```sh
 go build -o observe-agent
@@ -62,7 +62,7 @@ To start the observe agent after building the binary run the following command.
 
 ## Components
 
-Current OTEL Collector Version: `v0.110.0`
+Current OTEL Collector Version: `v0.118.0`
 
 This section lists the components that are included in the Observe Distribution of the OpenTelemetry Collector.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observeinc/observe-agent
 
-go 1.22.7
+go 1.22.8
 
 require (
 	github.com/jarcoal/httpmock v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -409,10 +409,6 @@ require (
 )
 
 replace (
-	// TODO remove these overrides when we upgrade to otelcol v0.117.0
-	github.com/docker/docker => github.com/docker/docker v27.4.1+incompatible
 	github.com/observeinc/observe-agent/components/processors/observek8sattributesprocessor v0.0.0-00010101000000-000000000000 => ./components/processors/observek8sattributesprocessor
 	github.com/observeinc/observe-agent/observecol => ./observecol
-	golang.org/x/crypto => golang.org/x/crypto v0.32.0
-	golang.org/x/net => golang.org/x/net v0.34.0
 )

--- a/go.work
+++ b/go.work
@@ -1,7 +1,7 @@
-go 1.22.7
+go 1.22.8
 
 use (
 	.
-	./observecol
 	./components/processors/observek8sattributesprocessor
+	./observecol
 )

--- a/observecol/go.mod
+++ b/observecol/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/observeinc/observe-agent/observecol
 
-go 1.22.7
+go 1.22.8
 
 require (
 	github.com/observeinc/observe-agent v0.0.0-00010101000000-000000000000

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -1195,6 +1195,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4180,6 +4181,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5750,6 +5752,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.
@@ -11632,6 +11635,7 @@ paths:
             example:
               ListenAddr: "0.0.0.0:2377"
               AdvertiseAddr: "192.168.1.1:2377"
+              DataPathAddr: "192.168.1.1"
               RemoteAddrs:
                 - "node1:2377"
               JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"

--- a/vendor/github.com/docker/docker/api/types/container/hostconfig.go
+++ b/vendor/github.com/docker/docker/api/types/container/hostconfig.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
-	units "github.com/docker/go-units"
+	"github.com/docker/go-units"
 )
 
 // CgroupnsMode represents the cgroup namespace mode of the container

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -316,7 +316,7 @@ github.com/digitalocean/godo/metrics
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/docker/docker v27.5.0+incompatible => github.com/docker/docker v27.4.1+incompatible
+# github.com/docker/docker v27.5.0+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -2124,7 +2124,7 @@ go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# golang.org/x/crypto v0.32.0 => golang.org/x/crypto v0.32.0
+# golang.org/x/crypto v0.32.0
 ## explicit; go 1.20
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/chacha20poly1305
@@ -2148,9 +2148,9 @@ golang.org/x/exp/slices
 # golang.org/x/mod v0.22.0
 ## explicit; go 1.22.0
 golang.org/x/mod/semver
-# golang.org/x/net v0.29.0 => golang.org/x/net v0.34.0
+# golang.org/x/net v0.29.0
 ## explicit; go 1.18
-# golang.org/x/net v0.34.0 => golang.org/x/net v0.34.0
+# golang.org/x/net v0.34.0
 ## explicit; go 1.18
 golang.org/x/net/bpf
 golang.org/x/net/context
@@ -2858,6 +2858,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/docker/docker => github.com/docker/docker v27.4.1+incompatible
-# golang.org/x/crypto => golang.org/x/crypto v0.32.0
-# golang.org/x/net => golang.org/x/net v0.34.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -835,11 +835,11 @@ github.com/munnerz/goautoneg
 ## explicit
 github.com/mwitkow/go-conntrack
 # github.com/observeinc/observe-agent v0.0.0-00010101000000-000000000000 => .
-## explicit; go 1.22.7
+## explicit; go 1.22.8
 # github.com/observeinc/observe-agent/components/processors/observek8sattributesprocessor v0.0.0-00010101000000-000000000000 => ./components/processors/observek8sattributesprocessor
 ## explicit; go 1.22.7
 # github.com/observeinc/observe-agent/observecol v0.0.0-00010101000000-000000000000 => ./observecol
-## explicit; go 1.22.7
+## explicit; go 1.22.8
 # github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.118.0
 ## explicit; go 1.22.0
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector


### PR DESCRIPTION
### Description

Upgrade go version to 1.22.8

This also includes removing the go module replacements. I verified the high/critical CVEs are still fixed:
```
$ docker scout cves sha256:07a15d55106aded0734018ebd61141bfe3fa9b9aa99ae6dfe0261951540cceb3
    ✓ Image stored for indexing
    ✓ Indexed 405 packages
    ✓ Provenance obtained from attestation
    ✗ Detected 3 vulnerable packages with a total of 5 vulnerabilities


## Overview

                    │                              Analyzed Image                                
────────────────────┼────────────────────────────────────────────────────────────────────────────
  Target            │  sha256:07a15d55106aded0734018ebd61141bfe3fa9b9aa99ae6dfe0261951540cceb3   
    digest          │  07a15d55106a                                                              
    platform        │ linux/arm64                                                                
    vulnerabilities │    0C     0H     4M     1L                                                 
    size            │ 49 MB                                                                      
    packages        │ 405                                                                        


## Packages and Vulnerabilities

   0C     0H     2M     0L  stdlib 1.22.8
pkg:golang/stdlib@1.22.8

    ✗ MEDIUM CVE-2024-45341
      https://scout.docker.com/v/CVE-2024-45341
      Affected range : <1.22.11  
      Fixed version  : 1.22.11   
    
    ✗ MEDIUM CVE-2024-45336
      https://scout.docker.com/v/CVE-2024-45336
      Affected range : <1.22.11  
      Fixed version  : 1.22.11   
    

   0C     0H     1M     1L  github.com/aws/aws-sdk-go 1.55.6
pkg:golang/github.com/aws/aws-sdk-go@1.55.6

    ✗ MEDIUM CVE-2020-8911
      https://scout.docker.com/v/CVE-2020-8911
      Affected range : >=0        
      Fixed version  : not fixed  
    
    ✗ LOW CVE-2020-8912
      https://scout.docker.com/v/CVE-2020-8912
      Affected range : >=0        
      Fixed version  : not fixed  
    

   0C     0H     1M     0L  openssl 3.3.2-r0
pkg:apk/alpine/openssl@3.3.2-r0?os_name=alpine&os_version=3.20

    ✗ MEDIUM CVE-2024-9143
      https://scout.docker.com/v/CVE-2024-9143
      Affected range : <3.3.2-r1  
      Fixed version  : 3.3.2-r1   
    


5 vulnerabilities found in 3 packages
  CRITICAL  0  
  HIGH      0  
  MEDIUM    4  
  LOW       1  
```

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary