### PR TITLE
fix: send logs/agent-config over otlp as intended

### DIFF
--- a/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
+++ b/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml
@@ -29,4 +29,4 @@ service:
     logs/agent-config:
        receivers: [filelog/agent-config]
        processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [prometheusremotewrite/observe]
+       exporters: [otlphttp/observe]


### PR DESCRIPTION
### Description

Send logs/agent-config over otlp as intended. This pipeline was mistakenly switched to prometheus.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary