### PR TITLE
fix: ensure provided env var OBSERVE_COLLECTOR_URL never ends in a slash

### DIFF
--- a/internal/connections/confighandler.go
+++ b/internal/connections/confighandler.go
@@ -74,6 +74,12 @@ func GetAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, er
 
 func SetEnvVars() error {
 	collector_url, token, debug := viper.GetString("observe_url"), viper.GetString("token"), viper.GetBool("debug")
+	// Ensure the collector url does not end with a slash for consistency. This will allow endpoints to be configured like:
+	// "${env:OBSERVE_COLLECTOR_URL}/v1/kubernetes/v1/entity"
+	// without worrying about a double slash.
+	if collector_url[len(collector_url)-1] == '/' {
+		collector_url = collector_url[:len(collector_url)-1]
+	}
 	otelEndpoint, err := url.JoinPath(collector_url, "/v2/otel")
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

Ensure provided env var OBSERVE_COLLECTOR_URL never ends in a slash. Providing a consistent format regardless of how the agent is configured will make using this downstream easier and more reliable.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary