### PR TITLE
fix: always re-add config values provided with --config after internal config values

### DIFF
--- a/internal/commands/start/start.go
+++ b/internal/commands/start/start.go
@@ -6,6 +6,7 @@ package start
 import (
 	"context"
 	"os"
+	"strings"
 
 	logger "github.com/observeinc/observe-agent/internal/commands/util"
 	"github.com/observeinc/observe-agent/internal/connections"
@@ -55,7 +56,7 @@ collector on the current host.`
 	// Modify the run function so we can pass in our packaged config files.
 	originalRunE := otleCmd.RunE
 	otleCmd.RunE = func(cmd *cobra.Command, args []string) error {
-		configFilePaths, cleanup, err := SetupAndGetConfigFiles(DefaultLoggerCtx())
+		observeAgentConfigs, cleanup, err := SetupAndGetConfigFiles(DefaultLoggerCtx())
 		if cleanup != nil {
 			defer cleanup()
 		}
@@ -63,7 +64,26 @@ collector on the current host.`
 			return err
 		}
 		configFlag := otleCmd.Flags().Lookup("config")
-		for _, path := range configFilePaths {
+		// The otelcol config flag has a lot of functionality that we want to utilize, but the flag isn't exposed to
+		// the library's callers in the code. Our workaround is to use the original otelcol command as our `start`
+		// command and add our bundled config files to the config flag.
+		//
+		// However, we want any overrides that users provide via `--config` to take precedence, so we need to add our
+		// config values _before_ any current values. Since we can only append to the end of the flag, we add our
+		// bundled configs, then *re-add* the original config values.
+		originalConfigStr := configFlag.Value.String()
+		// This string is formatted as "[path1, path2, ...]"
+		// see: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/otelcol/flags.go#L28-L30
+		// Trim the surrounding brackets, then split on ", "
+		var originalConfigs []string
+		if len(originalConfigStr) > 2 {
+			originalConfigStr = originalConfigStr[1 : len(originalConfigStr)-1]
+			originalConfigs = strings.Split(originalConfigStr, ", ")
+		}
+		for _, path := range observeAgentConfigs {
+			configFlag.Value.Set(path)
+		}
+		for _, path := range originalConfigs {
 			configFlag.Value.Set(path)
 		}
 		return originalRunE(cmd, args)


### PR DESCRIPTION
### Description

After switching to the otelcol's internal `--config` flag, the bundled config files provided by the `observe-agent` now are processed _after_ any configuration provided with `--config`. This makes it so the bundled config values cannot be overwritten via the `--config` flag (only via the `otel_config_overrides` option). This fix makes the flag take precedence again.

Ex:
```
$ cat ./hc_test.yaml 
extensions:
  health_check:
    endpoint: 0.0.0.0:13137
```

Current 2.0.0:
```
$ observe-agent start --config ./hc_test.yaml 
# ...
2025-02-10T11:10:54.862-0600	info	healthcheckextension/healthcheckextension.go:32	Starting health_check extension	{"kind": "extension", "name": "health_check", "config": {"Endpoint":"localhost:13133","TLSSetting":null,"CORS":null,"Auth":null,"MaxRequestBodySize":0,"IncludeMetadata":false,"ResponseHeaders":null,"CompressionAlgorithms":null,"ReadTimeout":0,"ReadHeaderTimeout":0,"WriteTimeout":0,"IdleTimeout":0,"Path":"/status","ResponseBody":null,"CheckCollectorPipeline":{"Enabled":false,"Interval":"5m","ExporterFailureThreshold":5}}}
```
^ note the `"Endpoint":"localhost:13133"`


After this fix:
```
$ ./observe-agent start --config ./hc_test.yaml 
# ...
2025-02-10T11:11:41.227-0600	info	healthcheckextension/healthcheckextension.go:32	Starting health_check extension	{"kind": "extension", "name": "health_check", "config": {"Endpoint":"0.0.0.0:13137","TLSSetting":null,"CORS":null,"Auth":null,"MaxRequestBodySize":0,"IncludeMetadata":false,"ResponseHeaders":null,"CompressionAlgorithms":null,"ReadTimeout":0,"ReadHeaderTimeout":0,"WriteTimeout":0,"IdleTimeout":0,"Path":"/status","ResponseBody":null,"CheckCollectorPipeline":{"Enabled":false,"Interval":"5m","ExporterFailureThreshold":5}}}
```
^ note the `"Endpoint":"0.0.0.0:13137"`

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary