### PR TITLE
fix: make full use of nightly build functionality by publishing github releases and not tagging docker images as latest

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -22,7 +22,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.4.4
+          version: 2.7.0
           args: changelog
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -26,17 +26,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.12
-      - name: Install msitools
-        run: sudo apt-get install -y wixl
-      # More assembly might be required: Docker logins, GPG, etc.
-      # It all depends on your needs.
       - name: Install qemu
         uses: docker/setup-qemu-action@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '2.4.4'
+          version: 2.7.0
           args: release --prepare --clean --snapshot --verbose
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -23,6 +23,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
+      - name: Update the dev-nightly tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/dev-nightly',
+              sha: context.sha,
+              force: true
+            })
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -40,9 +40,6 @@ jobs:
         with:
           go-version: 1.22.12
 
-      - name: Install msitools
-        run: sudo apt-get install -y wixl
-
       - name: Install qemu
         uses: docker/setup-qemu-action@v3
 
@@ -67,7 +64,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.4.4
+          version: 2.7.0
           args: release --clean --skip=validate --verbose --nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,6 @@ jobs:
         with:
           go-version: 1.22.12
 
-      - name: Install msitools
-        run: sudo apt-get install -y wixl
-
       - name: Install qemu
         uses: docker/setup-qemu-action@v3
 
@@ -59,10 +56,9 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.4.4
+          version: 2.7.0
           args: release --clean --skip=validate --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -34,16 +34,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.12     
-      - name: Install msitools
-        run: sudo apt-get install -y wixl    
+          go-version: 1.22.12
       - name: Install qemu
         uses: docker/setup-qemu-action@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '2.4.4'
+          version: 2.7.0
           args: release --prepare --clean --snapshot --verbose --parallelism 8
         env:         
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.4.4
+          version: 2.7.0
           args: build --snapshot --id=default --skip=validate --single-target
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,16 +180,20 @@ nfpms:
         dst: /lib/systemd/system/observe-agent.service
         type: config
 
-    # Scripts to execute during the installation of the package. (overridable)
-    #
-    # Keys are the possible targets during the installation process
-    # Values are the paths to the scripts which will be executed.
-    #
-    # Templates: allowed (since v1.20)
     scripts:
       preinstall: "packaging/linux/scripts/preinstall.sh"
       postinstall: "packaging/linux/scripts/postinstall.sh"
       preremove: "packaging/linux/scripts/preremove.sh"
+
+nightly:
+  tag_name: dev-nightly
+  publish_release: true
+  keep_single_release: true
+
+release:
+  make_latest: "{{ if .IsNightly }}false{{ else }}true{{ end }}"
+  prerelease: "{{ if .IsNightly }}true{{ else }}false{{ end }}"
+  tag: "{{ if .IsNightly}}dev-nightly{{ else }}{{ .CurrentTag }}{{ end }}"
 
 dockers:
   - image_templates:
@@ -220,308 +224,24 @@ docker_manifests:
     image_templates:
       - *amd64_image_dockerhub
       - *arm64v8_image_dockerhub
-  - name_template: "docker.io/observeinc/observe-agent:latest"
+  - name_template: "docker.io/observeinc/observe-agent:{{ if .IsNightly}}dev-nightly{{ else }}latest{{ end }}"
     image_templates:
       - *amd64_image_dockerhub
       - *arm64v8_image_dockerhub
-  - name_template: 723346149663.dkr.ecr.us-west-2.amazonaws.com/observe-agent:{{ .Version }}
+  - name_template: "723346149663.dkr.ecr.us-west-2.amazonaws.com/observe-agent:{{ .Version }}"
     image_templates:
       - *amd64_image_ecr
       - *arm64v8_image_ecr
-  - name_template: 723346149663.dkr.ecr.us-west-2.amazonaws.com/observe-agent:latest
+  - name_template: "723346149663.dkr.ecr.us-west-2.amazonaws.com/observe-agent:{{ if .IsNightly}}dev-nightly{{ else }}latest{{ end }}"
     image_templates:
       - *amd64_image_ecr
       - *arm64v8_image_ecr
-
-msi:
-  - # ID of the resulting installer.
-    #
-    # Default: the project name
-    # id: foo
-
-    # Filename of the installer (without the extension).
-    #
-    # Default: '{{.ProjectName}}_{{.MsiArch}}'
-    # Templates: allowed
-    name: "observe-agent_{{ .Version }}-{{.MsiArch}}"
-
-    # The WXS file used to create the installers.
-    # The file contents go through the templating engine, so you can do things
-    # like `{{.Version}}` inside of it.
-    #
-    # Templates: allowed
-    # Required.
-    wxs: ./packaging/windows/app.wsx
-
-    # IDs of the archives to use.
-    # Empty means all IDs.
-    # ids:
-    #   - foo
-    #   - bar
-
-    # GOAMD64 to specify which amd64 version to use if there are multiple
-    # versions from the build section.
-    #
-    # Default: v1
-    goamd64: v1
-
-    # More files that will be available in the context in which the installer
-    # will be built.
-    # extra_files:
-    #   - logo.ico
-
-    # Whether to remove the archives from the artifact list.
-    # If left as false, your end release will have both the zip and the msi
-    # files.
-    replace: false
-
-    # Set the modified timestamp on the output installer, typically
-    # you would do this to ensure a build was reproducible.
-    # Pass an empty string to skip modifying the output.
-    #
-    # Templates: allowed.
-    mod_timestamp: "{{ .CommitTimestamp }}"
-
-brews:
-  -
-    # Name of the recipe
-    #
-    # Default: ProjectName
-    # Templates: allowed
-    name: observe-agent
-
-    # Alternative names for the current recipe.
-    #
-    # Useful if you want to publish a versioned formula as well, so users can
-    # more easily downgrade.
-    #
-    # Since: v1.20 (pro)
-    # Templates: allowed
-    # alternative_names:
-    #   - myproject@{{ .Version }}
-    #   - myproject@{{ .Major }}
-
-    # IDs of the archives to use.
-    # Empty means all IDs.
-    # ids:
-    # - foo
-    # - bar
-
-    # Sets the app file within a DMG.
-    #
-    # Since: 1.24 (pro)
-    # app: MyApp.app
-
-    # GOARM to specify which 32-bit arm version to use if there are multiple
-    # versions from the build section. Brew formulas support only one 32-bit
-    # version.
-    #
-    # Default: 6
-    goarm: 6
-
-    # GOAMD64 to specify which amd64 version to use if there are multiple
-    # versions from the build section.
-    #
-    # Default: v1
-    goamd64: v1
-
-    # NOTE: make sure the url_template, the token and given repo (github or
-    # gitlab) owner and name are from the same kind.
-    # We will probably unify this in the next major version like it is
-    # done with scoop.
-
-    # URL which is determined by the given Token (github, gitlab or gitea).
-    #
-    # Default depends on the client.
-    # Templates: allowed
-    # url_template: "https://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-
-    # Headers to include in the `url` stanza.
-    # This can be a more modern alternative to `download_strategy` in some
-    # cases.
-    #
-    # Since: v1.25
-    # url_headers:
-    #   - "Accept: application/octet-stream"
-    #   - 'Authorization: bearer #{ENV["HOMEBREW_GITHUB_API_TOKEN"]}'
-
-    # Allows you to set a custom download strategy. Note that you'll need
-    # to implement the strategy and add it to your tap repository.
-    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
-    # download_strategy: CurlDownloadStrategy
-    # download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
-
-    # Allows you to add a custom require_relative at the top of the formula
-    # template.
-    # custom_require: custom_download_strategy
-
-    # Git author used to commit to the repository.
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-
-    # The project name and current git tag are used in the format string.
-    #
-    # Templates: allowed
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-
-    # Directory inside the repository to put the formula.
-    # directory: Formula
-
-    # Caveats for the user of your binary.
-    # caveats: "How to use this binary"
-
-    # Your app's homepage.
-    homepage: "https://observeinc.com/"
-
-    # Your app's description.
-    #
-    # Templates: allowed
-    description: "Observe-Agent is a tool for collecting and exporting metrics from your infrastructure."
-
-    # SPDX identifier of your app's license.
-    license: "Apache-2.0"
-
-    # Setting this will prevent goreleaser to actually try to commit the updated
-    # formula - instead, the formula file will be stored on the dist directory
-    # only, leaving the responsibility of publishing it to the user.
-    # If set to auto, the release will not be uploaded to the homebrew tap
-    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
-    #
-    # Templates: allowed
-    skip_upload: true
-
-    # Custom block for brew.
-    # Can be used to specify alternate downloads for devel or head releases.
-    # custom_block: |
-    #   head "https://github.com/some/package.git"
-    #   ...
-
-    # Packages your package depends on.
-    # dependencies:
-    #   - name: git
-    #     # Allow to specify the OS in which the dependency is required.
-    #     # Valid options are `mac` and `linux`.
-    #     #
-    #     # Since: v1.23.0
-    #     os: mac
-    #   - name: zsh
-    #     type: optional
-    #   - name: fish
-    #     version: v1.2.3
-    #   # if providing both version and type, only the type will be taken into
-    #   # account.
-    #   - name: elvish
-    #     type: optional
-    #     version: v1.2.3
-
-
-    # Packages that conflict with your package.
-    # conflicts:
-    #   - svn
-    #   - bash
-
-    # Specify for packages that run as a service.
-    # plist: |
-    #   <?xml version="1.0" encoding="UTF-8"?>
-    #   # ...
-
-    # Service block.
-    #
-    # Since: v1.7
-    # service: |
-    #   run: foo/bar
-    #   # ...
-
-    # So you can `brew test` your formula.
-    #
-    # Template: allowed
-    # test: |
-    #   system "#{bin}/foo --version"
-    #   # ...
-
-    # Custom install script for brew.
-    #
-    # Template: allowed
-    # Default: 'bin.install "BinaryName"'
-    # install: |
-    #   bin.install "some_other_name"
-    #   bash_completion.install "completions/foo.bash" => "foo"
-    #   # ...
-
-    # Additional install instructions so you don't need to override `install`.
-    #
-    # Template: allowed
-    # Since: v1.20
-    # extra_install: |
-    #   bash_completion.install "completions/foo.bash" => "foo"
-    #   man1.install "man/foo.1.gz"
-    #   # ...
-
-    # Custom post_install script for brew.
-    # Could be used to do any additional work after the "install" script
-    # post_install: |
-    #     etc.install "app-config.conf"
-    #   # ...
-
-    # Repository to push the generated files to.
-    repository:
-      # Repository owner.
-      #
-      # Templates: allowed
-      owner: observeinc
-
-      # Repository name.
-      #
-      # Templates: allowed
-      name: homebrew-tap
-
-      # Optionally a branch can be provided.
-      #
-      # Default: default repository branch
-      # Templates: allowed
-      branch: main
-
-      # Optionally a token can be provided, if it differs from the token
-      # provided to GoReleaser
-      # Templates: allowed
-      # token: "{{ .Env.GITHUB_PERSONAL_AUTH_TOKEN }}"
-
-      # Sets up pull request creation instead of just pushing to the given branch.
-      # Make sure the 'branch' property is different from base before enabling
-      # it.
-      #
-      # Since: v1.17
-      pull_request:
-        # Whether to enable it or not.
-        enabled: true
-
-        # Whether to open the PR as a draft or not.
-        #
-        # Since: v1.19
-        draft: true
-
-        # If the pull request template has checkboxes, enabling this will
-        # check all of them.
-        #
-        # This feature is only available in GoReleaser Pro.
-        # Since: v1.20 (pro)
-        check_boxes: true
-
-        # Base can also be another repository, in which case the owner and name
-        # above will be used as HEAD, allowing cross-repository pull requests.
-        #
-        # Since: v1.19
-        base:
-          # owner: goreleaser
-          # name: my-repo
-          branch: main
 
 git:
-  ignore_tag_prefixes:
-    - dev
-    - nightly
+  ignore_tags:
+    - "{{ if not .IsNightly }}dev-nightly{{ end }}"
 
 furies:
   - account: observeinc
-    disable: "{{ .IsNightly }}"
+    # TODO add a separate account for nightly releases
+    disable: "{{ if .IsNightly }}true{{ end }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -192,7 +192,6 @@ nightly:
 
 release:
   make_latest: "{{ if .IsNightly }}false{{ else }}true{{ end }}"
-  prerelease: "{{ if .IsNightly }}true{{ else }}false{{ end }}"
   tag: "{{ if .IsNightly}}dev-nightly{{ else }}{{ .CurrentTag }}{{ end }}"
 
 dockers:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,10 @@ param (
 
 $installer_url="https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Windows_x86_64.zip"
 if ($PSBoundParameters.ContainsKey('version')){
-    $installer_url="https://github.com/observeinc/observe-agent/releases/download/v$version/observe-agent_Windows_x86_64.zip"
+    if ($version -match '^\d') {
+        $version="v$version"
+    }
+    $installer_url="https://github.com/observeinc/observe-agent/releases/download/$version/observe-agent_Windows_x86_64.zip"
 }
 $local_installer="C:\temp\observe-agent_Windows_x86_64.zip"
 $program_data_filestorage="C:\ProgramData\Observe\observe-agent\filestorage"

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -61,8 +61,11 @@ fi
 # If the zip file is not provided, download the latest release from GitHub.
 if [ -z "$ZIP_DIR" ]; then
     if [ -n "$AGENT_VERSION" ]; then
+        if [[ $AGENT_VERSION =~ ^[[:digit:]] ]]; then
+            AGENT_VERSION="v$AGENT_VERSION"
+        fi
         echo "Downloading version $AGENT_VERSION from GitHub..."
-        curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/download/v$AGENT_VERSION/observe-agent_Linux_$(arch).tar.gz
+        curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/download/$AGENT_VERSION/observe-agent_Linux_$(arch).tar.gz
     else
         echo "Downloading latest release from GitHub..."
         curl -s -L -o /tmp/observe-agent.tar.gz https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Linux_$(arch).tar.gz

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -64,8 +64,11 @@ fi
 # If the zip file is not provided, download the latest release from GitHub.
 if [ -z "$ZIP_DIR" ]; then
     if [ -n "$AGENT_VERSION" ]; then
+        if [[ $AGENT_VERSION =~ ^[[:digit:]] ]]; then
+            AGENT_VERSION="v$AGENT_VERSION"
+        fi
         echo "Downloading version $AGENT_VERSION from GitHub..."
-        curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/download/v$AGENT_VERSION/observe-agent_Darwin_$(arch).zip
+        curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/download/$AGENT_VERSION/observe-agent_Darwin_$(arch).zip
     else
         echo "Downloading latest release from GitHub..."
         curl -s -L -o /tmp/observe-agent.zip https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent_Darwin_$(arch).zip


### PR DESCRIPTION
### Description

The objective of this change is to create github releases and publish docker images whenever we do a nightly build, but not tag either as `latest` (and instead use tag `dev-nightly`). Before this change: no github releases were published, and docker builds were published and tagged `latest`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary