### PR TITLE
fix: do not create releases when tag is dev or nightly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     # run only against tags
     tags:
       - "*"
+      # Ignore nightly/dev tags
+      - "!nightly*"
+      - "!dev*"
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Description

In order to create a release on github, we need to create a git tag. This filter will ensure we don't trigger a real release when tagging a nightly release.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary