### PR TITLE
Add default package routing headers

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -61,11 +61,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run GoReleaser
+        timeout-minutes: 15
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
           version: 2.7.0
-          args: release --clean --skip=validate --verbose --nightly
+          args: release --clean --skip=validate --verbose --nightly --parallelism 6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   goreleaser:
-    if: contains('["obs-gh-alexlew", "obs-gh-mattcotter", "obs-gh-enricogiorio"]', github.actor)
+    if: contains('["obs-gh-alexlew", "obs-gh-mattcotter", "obs-gh-enricogiorio", "obs-gh-jabernet"]', github.actor)
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout

--- a/packaging/docker/observe-agent/otel-collector.yaml
+++ b/packaging/docker/observe-agent/otel-collector.yaml
@@ -89,6 +89,7 @@ exporters:
     endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     sending_queue:
       num_consumers: 4
       queue_size: 100
@@ -100,9 +101,22 @@ exporters:
     endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     resource_to_telemetry_conversion:
       enabled: true  # Convert resource attributes to metric labels
     send_metadata: true
+
+  otlphttp/observetracing:
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+    headers:
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Tracing"
+    sending_queue:
+      num_consumers: 4
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+    compression: zstd
 
   debug:
 
@@ -121,7 +135,7 @@ service:
     traces/forward:
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
-      exporters: [otlphttp/observe]
+      exporters: [otlphttp/observetracing]
 
     metrics/count-nooop:
       receivers: [count]

--- a/packaging/linux/etc/observe-agent/otel-collector.yaml
+++ b/packaging/linux/etc/observe-agent/otel-collector.yaml
@@ -89,6 +89,7 @@ exporters:
     endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     sending_queue:
       num_consumers: 4
       queue_size: 100
@@ -100,9 +101,22 @@ exporters:
     endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     resource_to_telemetry_conversion:
       enabled: true  # Convert resource attributes to metric labels
     send_metadata: true
+
+  otlphttp/observetracing:
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+    headers:
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Tracing"
+    sending_queue:
+      num_consumers: 4
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+    compression: zstd
 
   debug:
 
@@ -121,7 +135,7 @@ service:
     traces/forward:
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
-      exporters: [otlphttp/observe]
+      exporters: [otlphttp/observetracing]
 
     metrics/count-nooop:
       receivers: [count]

--- a/packaging/macos/config/otel-collector.yaml
+++ b/packaging/macos/config/otel-collector.yaml
@@ -89,6 +89,7 @@ exporters:
     endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     sending_queue:
       num_consumers: 4
       queue_size: 100
@@ -100,9 +101,22 @@ exporters:
     endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     resource_to_telemetry_conversion:
       enabled: true  # Convert resource attributes to metric labels
     send_metadata: true
+
+  otlphttp/observetracing:
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+    headers:
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Tracing"
+    sending_queue:
+      num_consumers: 4
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+    compression: zstd
 
   debug:
 
@@ -121,7 +135,7 @@ service:
     traces/forward:
       receivers: [otlp]
       processors: [resourcedetection, resourcedetection/cloud]
-      exporters: [otlphttp/observe]
+      exporters: [otlphttp/observetracing]
 
     metrics/count-nooop:
       receivers: [count]

--- a/packaging/windows/config/otel-collector.yaml
+++ b/packaging/windows/config/otel-collector.yaml
@@ -69,6 +69,7 @@ exporters:
     endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     sending_queue:
       num_consumers: 4
       queue_size: 100
@@ -80,9 +81,22 @@ exporters:
     endpoint: ${env:OBSERVE_PROMETHEUS_ENDPOINT}
     headers:
       authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Host Explorer"
     resource_to_telemetry_conversion:
       enabled: true  # Convert resource attributes to metric labels
     send_metadata: true
+
+  otlphttp/observetracing:
+    endpoint: ${env:OBSERVE_OTEL_ENDPOINT}
+    headers:
+      authorization: ${env:OBSERVE_AUTHORIZATION_HEADER}
+      x-observe-target-package: "Tracing"
+    sending_queue:
+      num_consumers: 4
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+    compression: zstd
 
   debug:
 
@@ -101,7 +115,7 @@ service:
     traces/forward:
       receivers: [otlp]
       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-      exporters: [otlphttp/observe]
+      exporters: [otlphttp/observetracing]
 
     metrics/count-nooop:
       receivers: [count]


### PR DESCRIPTION
In order for the out of box routing to work, send all traces to shared "Tracing" package and all other data to host connection specific "Host Explorer".

In the future those will be configurable.

### Description
https://observe.atlassian.net/browse/OB-41698

