### PR TITLE
fix: only block release on fixed issues with higher severity than low

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   vuln-check:
-    name: Docker Image Vulnerability Check
-    uses: ./.github/workflows/vuln-check.yaml
+    name: Pre-release Docker Image Vulnerability Check
+    uses: ./.github/workflows/vuln-check-release.yaml
     secrets: inherit
     with:
       branch: ${{ github.ref }}

--- a/.github/workflows/vuln-check-full.yaml
+++ b/.github/workflows/vuln-check-full.yaml
@@ -7,11 +7,6 @@ on:
         description: "The branch on which to run the vulnerability check"
         required: true
         default: "main"
-  workflow_call:
-    inputs:
-      branch:
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -57,7 +52,7 @@ jobs:
           cp dist/linux_amd64/default_linux_amd64_v1/observe-agent .
       
       - name: Build an image from Dockerfile
-        run: docker build -f packaging/docker/Dockerfile -t docker.io/${{ env.TEST_TAG}} .
+        run: docker build -f packaging/docker/Dockerfile -t docker.io/${{ env.TEST_TAG }} .
 
       - name: Docker Scout
         id: docker-scout

--- a/.github/workflows/vuln-check-release.yaml
+++ b/.github/workflows/vuln-check-release.yaml
@@ -1,0 +1,67 @@
+name: Pre-release Docker Image Vulnerability Check
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  TEST_TAG: observeinc/observe-agent:test
+
+jobs:
+  vuln-check:
+    runs-on: ubuntu-observe-agent-8cpu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.7
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          version: 2.7.0
+          args: build --snapshot --id=default --skip=validate --single-target
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Copy Binary
+        run: |
+          cp dist/linux_amd64/default_linux_amd64_v1/observe-agent .
+      
+      - name: Build an image from Dockerfile
+        run: docker build -f packaging/docker/Dockerfile -t docker.io/${{ env.TEST_TAG }} .
+
+      - name: Docker Scout
+        id: docker-scout
+        uses: docker/scout-action@v1
+        with:
+          image: ${{ env.TEST_TAG }}
+          command: cves,recommendations
+          to-latest: true
+          ignore-base: true
+          ignore-unchanged: true
+          only-fixed: true
+          only-severities: medium,critical,high
+          exit-code: true


### PR DESCRIPTION
### Description

Only block release on fixed issues with higher severity than low. This will ensure we can still release in the 180 day window we have to fix low severity issues, or when we know about an issue that has no fix.