### PR TITLE
fix: use .Tag in goreleaser tag template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -192,7 +192,7 @@ nightly:
 
 release:
   make_latest: "{{ if .IsNightly }}false{{ else }}true{{ end }}"
-  tag: "{{ if .IsNightly}}dev-nightly{{ else }}{{ .CurrentTag }}{{ end }}"
+  tag: "{{ if .IsNightly}}dev-nightly{{ else }}{{ .Tag }}{{ end }}"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
### Description

Using `{{ .CurrentTag }}` failed in the latest release: https://github.com/observeinc/observe-agent/actions/runs/13976540750/job/39131810187

`CurrentTag` came from the goreleaser release github docs: https://goreleaser.com/customization/release/#github

Looking at [the code](https://github.com/goreleaser/goreleaser/blob/f9bc1caafab4f949f849900e2219814c78adaf72/pkg/context/context.go#L88), I wonder if the actual value ought to be `{{ .Git.CurrentTag }}`. But there are no uses of `CurrentTag` in templates in their repo.

Many of their tests reference `Tag`, which is detailed in the docs here: https://goreleaser.com/customization/templates/#common-fields

I was convinced by the use of `Tag` in their tests, so that's what I decided to try first. Unfortunately this `release.tag` feature is only available in pro, so I can't read the code and find the answer that way.