### PR TITLE
feat: add config command flag --render-otel to print full otel config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/observeinc/observe-agent
 go 1.23.7
 
 require (
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/observeinc/observe-agent/observecol v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_model v0.6.1
@@ -11,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.0-alpha.6
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/collector/confmap v1.27.0
 	go.opentelemetry.io/collector/otelcol v0.121.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.30.0
@@ -94,7 +96,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.4 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-resty/resty/v2 v2.13.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/go-zookeeper/zk v1.0.4 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
@@ -314,7 +315,6 @@ require (
 	go.opentelemetry.io/collector/config/configretry v1.27.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.121.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.27.0 // indirect
-	go.opentelemetry.io/collector/confmap v1.27.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.27.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.27.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.27.0 // indirect

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -8,12 +8,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/observeinc/observe-agent/internal/commands/start"
 	logger "github.com/observeinc/observe-agent/internal/commands/util"
 	"github.com/observeinc/observe-agent/internal/config"
 	"github.com/observeinc/observe-agent/internal/root"
+	"github.com/observeinc/observe-agent/observecol"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/otelcol"
 	"gopkg.in/yaml.v3"
 )
 
@@ -58,6 +62,77 @@ OTEL configuration.`,
 	},
 }
 
+var otelConfigSubCmd = &cobra.Command{
+	Use:   "export-otel",
+	Short: "Prints a single otel config file containing the full configuration that would run.",
+	Long: `This command prints a single otel config file containing all bundled configuration.
+Features that are enabled or disabled in the observe-agent config will be reflected in the output accordingly.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configFilePaths, cleanup, err := start.SetupAndGetConfigFiles(logger.WithCtx(context.Background(), logger.GetNop()))
+		if cleanup != nil {
+			defer cleanup()
+		}
+		if err != nil {
+			return err
+		}
+		fullVersion, err := cmd.Flags().GetBool("full")
+		if err != nil {
+			return err
+		}
+		if fullVersion {
+			return printFullOtelConfig(configFilePaths)
+		}
+		return printShortOtelConfig(cmd.Context(), configFilePaths)
+	},
+}
+
+func printShortOtelConfig(ctx context.Context, configFilePaths []string) error {
+	settings := observecol.ConfigProviderSettings(configFilePaths)
+	resolver, err := confmap.NewResolver(settings.ResolverSettings)
+	if err != nil {
+		return fmt.Errorf("failed to create new resolver: %w", err)
+	}
+	conf, err := resolver.Resolve(ctx)
+	if err != nil {
+		return fmt.Errorf("error while resolving config: %w", err)
+	}
+	b, err := yaml.Marshal(conf.ToStringMap())
+	if err != nil {
+		return fmt.Errorf("error while marshaling to YAML: %w", err)
+	}
+	fmt.Printf("%s\n", b)
+	return nil
+}
+
+func printFullOtelConfig(configFilePaths []string) error {
+	colSettings := observecol.GenerateCollectorSettingsWithConfigFiles(configFilePaths)
+	factories, err := colSettings.Factories()
+	if err != nil {
+		return fmt.Errorf("failed to initialize factories: %w", err)
+	}
+	provider, err := otelcol.NewConfigProvider(colSettings.ConfigProviderSettings)
+	if err != nil {
+		return fmt.Errorf("failed to create config provider: %w", err)
+	}
+	cfg, err := provider.Get(context.Background(), factories)
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+	var cfgMap map[string]any
+	err = mapstructure.Decode(cfg, &cfgMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshall config to map: %w", err)
+	}
+	cfgYaml, err := yaml.Marshal(cfgMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshall config to yaml: %w", err)
+	}
+	fmt.Printf("%s\n", cfgYaml)
+	return nil
+}
+
 func init() {
+	otelConfigSubCmd.Flags().Bool("full", false, "Print the full resolved configuration including default values instead of the pre-processed configuration.")
+	configCmd.AddCommand(otelConfigSubCmd)
 	root.RootCmd.AddCommand(configCmd)
 }

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -110,7 +110,7 @@ func printFullOtelConfig(configFilePaths []string) error {
 	colSettings := observecol.GenerateCollectorSettingsWithConfigFiles(configFilePaths)
 	factories, err := colSettings.Factories()
 	if err != nil {
-		return fmt.Errorf("failed to initialize factories: %w", err)
+		return fmt.Errorf("failed to create component factory maps: %w", err)
 	}
 	provider, err := otelcol.NewConfigProvider(colSettings.ConfigProviderSettings)
 	if err != nil {

--- a/observecol/otelcollector.go
+++ b/observecol/otelcollector.go
@@ -14,6 +14,21 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 )
 
+func ConfigProviderSettings(URIs []string) otelcol.ConfigProviderSettings {
+	return otelcol.ConfigProviderSettings{
+		ResolverSettings: confmap.ResolverSettings{
+			URIs: URIs,
+			ProviderFactories: []confmap.ProviderFactory{
+				fileprovider.NewFactory(),
+				envprovider.NewFactory(),
+				yamlprovider.NewFactory(),
+				httpprovider.NewFactory(),
+				httpsprovider.NewFactory(),
+			},
+		},
+	}
+}
+
 func GenerateCollectorSettings() *otelcol.CollectorSettings {
 	buildInfo := component.BuildInfo{
 		Command:     "observe-agent",
@@ -21,19 +36,9 @@ func GenerateCollectorSettings() *otelcol.CollectorSettings {
 		Version:     build.Version,
 	}
 	set := &otelcol.CollectorSettings{
-		BuildInfo: buildInfo,
-		Factories: components,
-		ConfigProviderSettings: otelcol.ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				ProviderFactories: []confmap.ProviderFactory{
-					fileprovider.NewFactory(),
-					envprovider.NewFactory(),
-					yamlprovider.NewFactory(),
-					httpprovider.NewFactory(),
-					httpsprovider.NewFactory(),
-				},
-			},
-		},
+		BuildInfo:              buildInfo,
+		Factories:              components,
+		ConfigProviderSettings: ConfigProviderSettings([]string{}),
 	}
 	return set
 }


### PR DESCRIPTION
### Description

Add the flags `--render-otel` and `--render-otel-details` to the `config` command to print full otel config. This short version is modeled after the `otelcol print` command, the long version was modeled after the startup command.

Ex:
```
$ ./observe-agent config --render-otel | tail -n 40
                - debug
            processors:
                - filter/count
            receivers:
                - count
        metrics/forward:
            exporters:
                - prometheusremotewrite/observe
            processors:
                - resourcedetection
                - resourcedetection/cloud
                - deltatocumulative
                - batch
            receivers:
                - otlp
        metrics/host_monitoring_host:
            exporters:
                - prometheusremotewrite/observe
            processors:
                - memory_limiter
                - resourcedetection
                - resourcedetection/cloud
                - batch
            receivers:
                - hostmetrics/host-monitoring-host
        traces/forward:
            exporters:
                - otlphttp/observetracing
            processors:
                - resourcedetection
                - resourcedetection/cloud
            receivers:
                - otlp
    telemetry:
        logs:
            level: INFO
        metrics:
            address: :8888
            level: detailed
```
vs
```
$ ./observe-agent config --render-otel-details | tail -n 40
            receivers:
                - otlp
            processors:
                - resourcedetection
                - resourcedetection/cloud
            exporters:
                - otlphttp/observe
                - count
    telemetry:
        logs:
            encoding: console
            error_output_paths:
                - stderr
            level: info
            output_paths:
                - stderr
            sampling:
                enabled: true
                initial: 10
                thereafter: 100
                tick: 10s
        metrics:
            address: :8888
            level: Detailed
            readers:
                - pull:
                    exporter:
                        prometheus:
                            host: ""
                            port: 8888
                            with_resource_constant_labels: {}
                            without_scope_info: true
                            without_type_suffix: true
                            without_units: true
                        additionalproperties: null
        traces:
            level: Basic
            processors: []
            propagators: []
```
