### PR TITLE
fix: add defaults for agent config to fully support nested env var overriders

### DIFF
--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/observeinc/observe-agent/internal/config"
 	"github.com/observeinc/observe-agent/internal/connections"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,7 +53,11 @@ func InitConfig() {
 		viper.SetConfigName("observe-agent")
 	}
 
+	// TODO consider setting this in our next major release to scope all agent env vars:
+	// viper.SetEnvPrefix("OBSERVE")
 	viper.AutomaticEnv() // read in environment variables that match
+
+	config.SetViperDefaults(viper.GetViper(), "::")
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
### Description

Add viper defaults for all agent config settings. Without this, nested env vars will be ignored unless the value is already set in the config. ex: `env HOST_MONITORING::ENABLED=true ./observe-agent start` will be ignored with an empty agent config.