### PR TITLE
fix: make install scripts backwards compatible

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,6 +21,7 @@ $temp_dir="C:\temp"
 
 New-Item -ItemType Directory -Force -Path $temp_dir
 New-Item -ItemType Directory -Force -Path $observeagent_install_dir
+New-Item -ItemType Directory -Force -Path $observeagent_install_dir\config
 New-Item -ItemType Directory -Force -Path $observeagent_install_dir\connections
 New-Item -ItemType Directory -Force -Path $program_data_filestorage
 
@@ -33,6 +34,9 @@ if((Get-Service ObserveAgent -ErrorAction SilentlyContinue)){
 
 Expand-Archive -Force -LiteralPath $local_installer -DestinationPath "$temp_dir\observe-agent_Windows_x86_64"
 Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\observe-agent.exe -Destination $observeagent_install_dir
+if (Test-Path $temp_dir\observe-agent_Windows_x86_64\otel-collector.yaml) {
+    Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\otel-collector.yaml -Destination $observeagent_install_dir\config\otel-collector.yaml
+}
 Copy-Item -Force -Path $temp_dir\observe-agent_Windows_x86_64\connections\* -Destination $observeagent_install_dir\connections -Recurse
 
 # If there's already an observe-agent.yaml we don't copy the template from the downloaded installation package and leave existing observe-agent.yaml alone

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -94,6 +94,9 @@ sudo cp -f $tmp_dir/observe-agent $agent_binary_path
 
 # Copy all config files to the proper dir.
 sudo rm -rf $observeagent_config_dir/otel-collector.yaml $observeagent_config_dir/connections
+if [ -f $tmp_dir/otel-collector.yaml ]; then
+    sudo cp -f $tmp_dir/otel-collector.yaml $observeagent_config_dir/otel-collector.yaml
+fi
 sudo cp -fR $tmp_dir/connections $observeagent_config_dir/connections
 sudo chown -R root:root $observeagent_config_dir
 

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -101,6 +101,9 @@ sudo chmod +rw /var/lib/observe-agent/filestorage
 # Copy all files to the install dir.
 sudo rm -rf $observeagent_install_dir/config $observeagent_install_dir/connections $observeagent_install_dir/observe-agent
 sudo cp $tmp_dir/observe-agent $observeagent_install_dir/observe-agent
+if [ -d $tmp_dir/config ]; then
+    sudo cp -R $tmp_dir/config $observeagent_install_dir/config
+fi
 sudo cp -R $tmp_dir/connections $observeagent_install_dir/connections
 sudo chown -R root:wheel $observeagent_install_dir
 


### PR DESCRIPTION
### Description

Make install scripts backwards compatible. This was accidentally broken in 97fbd007.