### PR TITLE
feat: improve internal_telemetry agent configuration

### DIFF
--- a/internal/commands/status/statusretriever.go
+++ b/internal/commands/status/statusretriever.go
@@ -109,12 +109,12 @@ func getMetricsSum(metrics []*io_prometheus_client.Metric) float64 {
 }
 
 func GetAgentMetrics(conf *config.AgentConfig) (*AgentMetrics, error) {
-	host := util.ReplaceEnvString(conf.InternalTelemetry.Host)
+	host := util.ReplaceEnvString(conf.InternalTelemetry.Metrics.Host)
 	if !strings.Contains(host, "://") {
 		host = "http://" + host
 	}
 	host = strings.TrimRight(host, ":/")
-	port := conf.InternalTelemetry.Port
+	port := conf.InternalTelemetry.Metrics.Port
 	baseURL := fmt.Sprintf("%s:%d", host, port)
 	return GetAgentMetricsFromEndpoint(baseURL)
 }

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -50,10 +50,22 @@ type ForwardingConfig struct {
 	Enabled bool `yaml:"enabled" mapstructure:"enabled" default:"true"`
 }
 
-type InternalTelemetryConfig struct {
+type InternalTelemetryMetricsConfig struct {
 	Enabled bool   `yaml:"enabled" mapstructure:"enabled" default:"true"`
 	Host    string `yaml:"host" mapstructure:"host" default:"localhost"`
 	Port    int    `yaml:"port" mapstructure:"port" default:"8888"`
+	Level   string `yaml:"level" mapstructure:"level" default:"detailed"`
+}
+
+type InternalTelemetryLogsConfig struct {
+	Enabled bool   `yaml:"enabled" mapstructure:"enabled" default:"true"`
+	Level   string `yaml:"level" mapstructure:"level" default:"${env:OTEL_LOG_LEVEL}"`
+}
+
+type InternalTelemetryConfig struct {
+	Enabled bool                           `yaml:"enabled" mapstructure:"enabled" default:"true"`
+	Metrics InternalTelemetryMetricsConfig `yaml:"metrics" mapstructure:"metrics"`
+	Logs    InternalTelemetryLogsConfig    `yaml:"logs" mapstructure:"logs"`
 }
 
 type AgentConfig struct {
@@ -63,7 +75,7 @@ type AgentConfig struct {
 	Debug                  bool                    `yaml:"debug,omitempty" mapstructure:"debug"`
 	HealthCheck            HealthCheckConfig       `yaml:"health_check" mapstructure:"health_check"`
 	Forwarding             ForwardingConfig        `yaml:"forwarding" mapstructure:"forwarding"`
-	InternalTelemetry      InternalTelemetryConfig `yaml:"internal_telemetry,omitempty" mapstructure:"internal_telemetry"`
+	InternalTelemetry      InternalTelemetryConfig `yaml:"internal_telemetry" mapstructure:"internal_telemetry"`
 	SelfMonitoring         SelfMonitoringConfig    `yaml:"self_monitoring,omitempty" mapstructure:"self_monitoring"`
 	HostMonitoring         HostMonitoringConfig    `yaml:"host_monitoring,omitempty" mapstructure:"host_monitoring"`
 	OtelConfigOverrides    map[string]any          `yaml:"otel_config_overrides,omitempty" mapstructure:"otel_config_overrides"`

--- a/internal/connections/confighandler.go
+++ b/internal/connections/confighandler.go
@@ -77,10 +77,12 @@ func SetEnvVars() error {
 	os.Setenv("OBSERVE_AUTHORIZATION_HEADER", "Bearer "+token)
 	os.Setenv("FILESTORAGE_PATH", GetDefaultFilestoragePath())
 
-	if debug {
-		os.Setenv("OTEL_LOG_LEVEL", "DEBUG")
-	} else {
-		os.Setenv("OTEL_LOG_LEVEL", "INFO")
+	if os.Getenv("OTEL_LOG_LEVEL") == "" {
+		if debug {
+			os.Setenv("OTEL_LOG_LEVEL", "DEBUG")
+		} else {
+			os.Setenv("OTEL_LOG_LEVEL", "INFO")
+		}
 	}
 	return nil
 }

--- a/packaging/docker/observe-agent/connections/common/internal_telemetry.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/common/internal_telemetry.yaml.tmpl
@@ -1,12 +1,16 @@
 service:
   telemetry:
+    {{- if .InternalTelemetry.Metrics.Enabled }}
     metrics:
-      level: detailed
+      level: {{ .InternalTelemetry.Metrics.Level }}
       readers:
         - pull:
             exporter:
               prometheus:
-                host: {{ .InternalTelemetry.Host }}
-                port: {{ .InternalTelemetry.Port }}
+                host: {{ .InternalTelemetry.Metrics.Host }}
+                port: {{ .InternalTelemetry.Metrics.Port }}
+    {{- end }}
+    {{- if .InternalTelemetry.Logs.Enabled }}
     logs:
-      level: ${env:OTEL_LOG_LEVEL}
+      level: {{ .InternalTelemetry.Logs.Level }}
+    {{- end }}

--- a/packaging/linux/connections/common/internal_telemetry.yaml.tmpl
+++ b/packaging/linux/connections/common/internal_telemetry.yaml.tmpl
@@ -1,12 +1,16 @@
 service:
   telemetry:
+    {{- if .InternalTelemetry.Metrics.Enabled }}
     metrics:
-      level: detailed
+      level: {{ .InternalTelemetry.Metrics.Level }}
       readers:
         - pull:
             exporter:
               prometheus:
-                host: {{ .InternalTelemetry.Host }}
-                port: {{ .InternalTelemetry.Port }}
+                host: {{ .InternalTelemetry.Metrics.Host }}
+                port: {{ .InternalTelemetry.Metrics.Port }}
+    {{- end }}
+    {{- if .InternalTelemetry.Logs.Enabled }}
     logs:
-      level: ${env:OTEL_LOG_LEVEL}
+      level: {{ .InternalTelemetry.Logs.Level }}
+    {{- end }}

--- a/packaging/macos/connections/common/internal_telemetry.yaml.tmpl
+++ b/packaging/macos/connections/common/internal_telemetry.yaml.tmpl
@@ -1,12 +1,16 @@
 service:
   telemetry:
+    {{- if .InternalTelemetry.Metrics.Enabled }}
     metrics:
-      level: detailed
+      level: {{ .InternalTelemetry.Metrics.Level }}
       readers:
         - pull:
             exporter:
               prometheus:
-                host: {{ .InternalTelemetry.Host }}
-                port: {{ .InternalTelemetry.Port }}
+                host: {{ .InternalTelemetry.Metrics.Host }}
+                port: {{ .InternalTelemetry.Metrics.Port }}
+    {{- end }}
+    {{- if .InternalTelemetry.Logs.Enabled }}
     logs:
-      level: ${env:OTEL_LOG_LEVEL}
+      level: {{ .InternalTelemetry.Logs.Level }}
+    {{- end }}

--- a/packaging/windows/connections/common/internal_telemetry.yaml.tmpl
+++ b/packaging/windows/connections/common/internal_telemetry.yaml.tmpl
@@ -1,12 +1,16 @@
 service:
   telemetry:
+    {{- if .InternalTelemetry.Metrics.Enabled }}
     metrics:
-      level: detailed
+      level: {{ .InternalTelemetry.Metrics.Level }}
       readers:
         - pull:
             exporter:
               prometheus:
-                host: {{ .InternalTelemetry.Host }}
-                port: {{ .InternalTelemetry.Port }}
+                host: {{ .InternalTelemetry.Metrics.Host }}
+                port: {{ .InternalTelemetry.Metrics.Port }}
+    {{- end }}
+    {{- if .InternalTelemetry.Logs.Enabled }}
     logs:
-      level: ${env:OTEL_LOG_LEVEL}
+      level: {{ .InternalTelemetry.Logs.Level }}
+    {{- end }}


### PR DESCRIPTION
### Description

Improve internal_telemetry agent configuration. Currently the only way in the agent to set logging to a level other than INFO or DEBUG is with custom otel config overrides. This allows for easy configuration via the agent config as well as respecting the env var `OTEL_LOG_LEVEL` if it's set outside the agent process.