### PR TITLE
feat: add config option to set service explorer attributes

### DIFF
--- a/integration/scripts/test_configure.py
+++ b/integration/scripts/test_configure.py
@@ -2,44 +2,47 @@
 import utils as u
 
 
-@u.print_test_decorator
-def run_test_windows(remote_host: u.Host, env_vars: dict) -> None:
-    init_command = r'Set-Location "C:\Program Files\Observe\observe-agent"; ./observe-agent init-config --token {} --observe_url {} --cloud_resource_detectors ec2'.format(
+def init_config_command(env_vars: dict) -> str:
+    return "init-config --token {} --observe_url {} --cloud_resource_detectors ec2 --resource_attributes deployment.environment=test".format(
         env_vars["observe_token"], env_vars["observe_url"]
     )
+
+
+def run_init_config_common(remote_host: u.Host, init_command: str) -> None:
+    # Print the config to be used first
+    result = remote_host.run_command(init_command + " --print")
+    print("Setting agent config:\n{}\n".format("=" * 21))
+    u.print_remote_result(result)
+    if result.exited != 0 or result.stderr:
+        raise ValueError("❌ Error in init-config print")
 
     # Set up correct config with observe url and token
     result = remote_host.run_command(init_command)
     if result.exited != 0 or result.stderr:
         u.print_remote_result(result)
         raise ValueError("❌ Error in init-config")
+
+
+@u.print_test_decorator
+def run_test_windows(remote_host: u.Host, env_vars: dict) -> None:
+    init_command = (
+        r'Set-Location "C:\Program Files\Observe\observe-agent"; ./observe-agent '
+        + init_config_command(env_vars)
+    )
+    run_init_config_common(remote_host, init_command)
 
 
 @u.print_test_decorator
 def run_test_docker(remote_host: u.Host, env_vars: dict) -> None:
     docker_prefix = u.get_docker_prefix(remote_host, False)
-    init_command = "{} init-config --token {} --observe_url {} --cloud_resource_detectors ec2".format(
-        docker_prefix, env_vars["observe_token"], env_vars["observe_url"]
-    )
-
-    # Set up correct config with observe url and token
-    result = remote_host.run_command(init_command)
-    if result.exited != 0 or result.stderr:
-        u.print_remote_result(result)
-        raise ValueError("❌ Error in init-config")
+    init_command = docker_prefix + " " + init_config_command(env_vars)
+    run_init_config_common(remote_host, init_command)
 
 
 @u.print_test_decorator
 def run_test_linux(remote_host: u.Host, env_vars: dict) -> None:
-    init_command = "sudo observe-agent init-config --token {} --observe_url {} --cloud_resource_detectors ec2".format(
-        env_vars["observe_token"], env_vars["observe_url"]
-    )
-
-    # Set up correct config with observe url and token
-    result = remote_host.run_command(init_command)
-    if result.exited != 0 or result.stderr:
-        u.print_remote_result(result)
-        raise ValueError("❌ Error in init-config")
+    init_command = "sudo observe-agent " + init_config_command(env_vars)
+    run_init_config_common(remote_host, init_command)
 
 
 if __name__ == "__main__":

--- a/integration/scripts/utils.py
+++ b/integration/scripts/utils.py
@@ -168,12 +168,7 @@ class Host(object):
         )
 
     def run_command(self, command) -> Result:
-        try:
-            with self._get_connection() as connection:
-                print("Running `{0}` on {1}".format(command, self.host_ip))
-                result = connection.run(command, warn=True, hide=True)
-        except (socket_error, AuthenticationException) as exc:
-            self._raise_authentication_err(exc)
+        result = self.run_command_unsafe(command)
 
         if result.failed:
             raise ExampleException(
@@ -185,6 +180,16 @@ class Host(object):
                     str(result.stdout) or "<empty>",
                 )
             )
+
+        return result
+
+    def run_command_unsafe(self, command) -> Result:
+        try:
+            with self._get_connection() as connection:
+                print("Running `{0}` on {1}".format(command, self.host_ip))
+                result = connection.run(command, warn=True, hide=True)
+        except (socket_error, AuthenticationException) as exc:
+            self._raise_authentication_err(exc)
 
         return result
 

--- a/internal/commands/initconfig/initconfig.go
+++ b/internal/commands/initconfig/initconfig.go
@@ -18,6 +18,7 @@ var (
 	token                                   string
 	observe_url                             string
 	cloud_resource_detectors                []string
+	resource_attributes                     map[string]string
 	self_monitoring_enabled                 bool
 	host_monitoring_enabled                 bool
 	host_monitoring_logs_enabled            bool
@@ -82,6 +83,9 @@ func RegisterConfigFlags(cmd *cobra.Command, v *viper.Viper) {
 
 	cmd.PersistentFlags().StringSliceVar(&cloud_resource_detectors, "cloud_resource_detectors", []string{}, "The cloud environments from which to detect resources")
 	v.BindPFlag("cloud_resource_detectors", cmd.PersistentFlags().Lookup("cloud_resource_detectors"))
+
+	cmd.PersistentFlags().StringToStringVar(&resource_attributes, "resource_attributes", map[string]string{}, "The cloud environments from which to detect resources")
+	v.BindPFlag("resource_attributes", cmd.PersistentFlags().Lookup("resource_attributes"))
 
 	cmd.PersistentFlags().BoolVar(&self_monitoring_enabled, "self_monitoring::enabled", true, "Enable self monitoring")
 	v.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -73,12 +73,22 @@ type AgentConfig struct {
 	ObserveURL             string                  `yaml:"observe_url" mapstructure:"observe_url"`
 	CloudResourceDetectors []string                `yaml:"cloud_resource_detectors,omitempty" mapstructure:"cloud_resource_detectors"`
 	Debug                  bool                    `yaml:"debug,omitempty" mapstructure:"debug"`
+	Attributes             map[string]string       `yaml:"attributes,omitempty" mapstructure:"attributes"`
+	ResourceAttributes     map[string]string       `yaml:"resource_attributes,omitempty" mapstructure:"resource_attributes"`
 	HealthCheck            HealthCheckConfig       `yaml:"health_check" mapstructure:"health_check"`
 	Forwarding             ForwardingConfig        `yaml:"forwarding" mapstructure:"forwarding"`
 	InternalTelemetry      InternalTelemetryConfig `yaml:"internal_telemetry" mapstructure:"internal_telemetry"`
 	SelfMonitoring         SelfMonitoringConfig    `yaml:"self_monitoring,omitempty" mapstructure:"self_monitoring"`
 	HostMonitoring         HostMonitoringConfig    `yaml:"host_monitoring,omitempty" mapstructure:"host_monitoring"`
 	OtelConfigOverrides    map[string]any          `yaml:"otel_config_overrides,omitempty" mapstructure:"otel_config_overrides"`
+}
+
+func (config *AgentConfig) HasAttributes() bool {
+	return len(config.Attributes) > 0
+}
+
+func (config *AgentConfig) HasResourceAttributes() bool {
+	return len(config.ResourceAttributes) > 0
 }
 
 func SetViperDefaults(v *viper.Viper, separator string) {

--- a/internal/connections/allconnectiontypes.go
+++ b/internal/connections/allconnectiontypes.go
@@ -25,6 +25,12 @@ var CommonConnectionType = MakeConnectionType(
 		},
 		{
 			enabledCheck: func(agentConfig *config.AgentConfig) bool {
+				return agentConfig.HasAttributes() || agentConfig.HasResourceAttributes()
+			},
+			colConfigFilePath: "attributes.yaml.tmpl",
+		},
+		{
+			enabledCheck: func(agentConfig *config.AgentConfig) bool {
 				return agentConfig.Forwarding.Enabled
 			},
 			colConfigFilePath: "forward.yaml.tmpl",

--- a/packaging/docker/observe-agent/connections/common/attributes.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/common/attributes.yaml.tmpl
@@ -1,0 +1,19 @@
+processors:
+  {{- if .HasAttributes }}
+  attributes/observe_global_attributes:
+    actions:
+    {{- range $key, $value := .Attributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}
+  {{- if .HasResourceAttributes }}
+  resource/observe_global_resource_attributes:
+    attributes:
+    {{- range $key, $value := .ResourceAttributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}

--- a/packaging/docker/observe-agent/connections/common/base.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/common/base.yaml.tmpl
@@ -41,7 +41,7 @@ processors:
         host.id:
           enabled: false
         os.type:
-           enabled: true
+          enabled: true
         host.arch:
           enabled: true
         host.name:

--- a/packaging/docker/observe-agent/connections/common/forward.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/common/forward.yaml.tmpl
@@ -23,15 +23,41 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        - deltatocumulative
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observe, count]
 
     traces/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observetracing]

--- a/packaging/docker/observe-agent/connections/host_monitoring/host.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/host_monitoring/host.yaml.tmpl
@@ -8,6 +8,16 @@ receivers:
 service:
   pipelines:
     metrics/agent-filestats:
-       receivers: [filestats/agent]
-       processors: [resourcedetection, resourcedetection/cloud]
-       exporters: [prometheusremotewrite/observe]
+      receivers: [filestats/agent]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [prometheusremotewrite/observe]

--- a/packaging/docker/observe-agent/connections/host_monitoring/host_metrics.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/host_monitoring/host_metrics.yaml.tmpl
@@ -36,5 +36,15 @@ service:
   pipelines:
     metrics/host_monitoring_host:
       receivers: [hostmetrics/host-monitoring-host]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/host_monitoring/logs.yaml.tmpl
@@ -41,10 +41,32 @@ service:
   pipelines:
     logs/host_monitoring-file:
       receivers: [filelog/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]
 
     logs/host_monitoring-journald:
       receivers: [journald/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]

--- a/packaging/docker/observe-agent/connections/host_monitoring/process_metrics.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/host_monitoring/process_metrics.yaml.tmpl
@@ -30,5 +30,15 @@ service:
   pipelines:
     metrics/host_monitoring_process:
       receivers: [hostmetrics/host-monitoring-process]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/self_monitoring/logs_and_metrics.yaml.tmpl
@@ -29,15 +29,49 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-journald:
       receivers: [journald/agent]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]
 
     logs/agent-config:
-       receivers: [filelog/agent-config]
-       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [otlphttp/observe]
+      receivers: [filelog/agent-config]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [otlphttp/observe]

--- a/packaging/linux/connections/common/attributes.yaml.tmpl
+++ b/packaging/linux/connections/common/attributes.yaml.tmpl
@@ -1,0 +1,19 @@
+processors:
+  {{- if .HasAttributes }}
+  attributes/observe_global_attributes:
+    actions:
+    {{- range $key, $value := .Attributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}
+  {{- if .HasResourceAttributes }}
+  resource/observe_global_resource_attributes:
+    attributes:
+    {{- range $key, $value := .ResourceAttributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}

--- a/packaging/linux/connections/common/base.yaml.tmpl
+++ b/packaging/linux/connections/common/base.yaml.tmpl
@@ -41,7 +41,7 @@ processors:
         host.id:
           enabled: false
         os.type:
-           enabled: true
+          enabled: true
         host.arch:
           enabled: true
         host.name:

--- a/packaging/linux/connections/common/forward.yaml.tmpl
+++ b/packaging/linux/connections/common/forward.yaml.tmpl
@@ -23,15 +23,41 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observe, count]
 
     traces/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observetracing]

--- a/packaging/linux/connections/host_monitoring/host.yaml.tmpl
+++ b/packaging/linux/connections/host_monitoring/host.yaml.tmpl
@@ -8,6 +8,16 @@ receivers:
 service:
   pipelines:
     metrics/agent-filestats:
-       receivers: [filestats/agent]
-       processors: [resourcedetection, resourcedetection/cloud]
-       exporters: [prometheusremotewrite/observe]
+      receivers: [filestats/agent]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [prometheusremotewrite/observe]

--- a/packaging/linux/connections/host_monitoring/host_metrics.yaml.tmpl
+++ b/packaging/linux/connections/host_monitoring/host_metrics.yaml.tmpl
@@ -35,5 +35,15 @@ service:
   pipelines:
     metrics/host_monitoring_host:
       receivers: [hostmetrics/host-monitoring-host]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/linux/connections/host_monitoring/logs.yaml.tmpl
+++ b/packaging/linux/connections/host_monitoring/logs.yaml.tmpl
@@ -41,10 +41,32 @@ service:
   pipelines:
     logs/host_monitoring-file:
       receivers: [filelog/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]
 
     logs/host_monitoring-journald:
       receivers: [journald/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]

--- a/packaging/linux/connections/host_monitoring/process_metrics.yaml.tmpl
+++ b/packaging/linux/connections/host_monitoring/process_metrics.yaml.tmpl
@@ -29,5 +29,15 @@ service:
   pipelines:
     metrics/host_monitoring_process:
       receivers: [hostmetrics/host-monitoring-process]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/linux/connections/self_monitoring/logs_and_metrics.yaml.tmpl
+++ b/packaging/linux/connections/self_monitoring/logs_and_metrics.yaml.tmpl
@@ -29,15 +29,49 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-journald:
       receivers: [journald/agent]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]
 
     logs/agent-config:
-       receivers: [filelog/agent-config]
-       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [otlphttp/observe]
+      receivers: [filelog/agent-config]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [otlphttp/observe]

--- a/packaging/macos/connections/common/attributes.yaml.tmpl
+++ b/packaging/macos/connections/common/attributes.yaml.tmpl
@@ -1,0 +1,19 @@
+processors:
+  {{- if .HasAttributes }}
+  attributes/observe_global_attributes:
+    actions:
+    {{- range $key, $value := .Attributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}
+  {{- if .HasResourceAttributes }}
+  resource/observe_global_resource_attributes:
+    attributes:
+    {{- range $key, $value := .ResourceAttributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}

--- a/packaging/macos/connections/common/base.yaml.tmpl
+++ b/packaging/macos/connections/common/base.yaml.tmpl
@@ -41,7 +41,7 @@ processors:
         host.id:
           enabled: false
         os.type:
-           enabled: true
+          enabled: true
         host.arch:
           enabled: true
         host.name:

--- a/packaging/macos/connections/common/forward.yaml.tmpl
+++ b/packaging/macos/connections/common/forward.yaml.tmpl
@@ -23,15 +23,41 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observe, count]
 
     traces/forward:
       receivers: [otlp]
-      processors: [resourcedetection, resourcedetection/cloud]
+      processors:
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
       exporters: [otlphttp/observetracing]

--- a/packaging/macos/connections/host_monitoring/host.yaml.tmpl
+++ b/packaging/macos/connections/host_monitoring/host.yaml.tmpl
@@ -8,6 +8,16 @@ receivers:
 service:
   pipelines:
     metrics/agent-filestats:
-       receivers: [filestats/agent]
-       processors: [resourcedetection, resourcedetection/cloud]
-       exporters: [prometheusremotewrite/observe]
+      receivers: [filestats/agent]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [prometheusremotewrite/observe]

--- a/packaging/macos/connections/host_monitoring/host_metrics.yaml.tmpl
+++ b/packaging/macos/connections/host_monitoring/host_metrics.yaml.tmpl
@@ -38,5 +38,15 @@ service:
   pipelines:
     metrics/host_monitoring_host:
       receivers: [hostmetrics/host-monitoring-host]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/macos/connections/host_monitoring/logs.yaml.tmpl
+++ b/packaging/macos/connections/host_monitoring/logs.yaml.tmpl
@@ -27,5 +27,16 @@ service:
   pipelines:
     logs/host_monitoring-file:
       receivers: [filelog/host_monitoring]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]

--- a/packaging/macos/connections/host_monitoring/process_metrics.yaml.tmpl
+++ b/packaging/macos/connections/host_monitoring/process_metrics.yaml.tmpl
@@ -29,5 +29,15 @@ service:
   pipelines:
     metrics/host_monitoring_process:
       receivers: [hostmetrics/host-monitoring-process]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml.tmpl
+++ b/packaging/macos/connections/self_monitoring/logs_and_metrics.yaml.tmpl
@@ -24,10 +24,33 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-config:
-       receivers: [filelog/agent-config]
-       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [otlphttp/observe]
+      receivers: [filelog/agent-config]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [otlphttp/observe]

--- a/packaging/windows/connections/common/attributes.yaml.tmpl
+++ b/packaging/windows/connections/common/attributes.yaml.tmpl
@@ -1,0 +1,19 @@
+processors:
+  {{- if .HasAttributes }}
+  attributes/observe_global_attributes:
+    actions:
+    {{- range $key, $value := .Attributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}
+  {{- if .HasResourceAttributes }}
+  resource/observe_global_resource_attributes:
+    attributes:
+    {{- range $key, $value := .ResourceAttributes }}
+      - key: {{ $key }}
+        value: {{ $value }}
+        action: insert
+    {{- end }}
+  {{- end }}

--- a/packaging/windows/connections/common/forward.yaml.tmpl
+++ b/packaging/windows/connections/common/forward.yaml.tmpl
@@ -23,15 +23,49 @@ service:
   pipelines:
     metrics/forward:
       receivers: [otlp]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/forward:
       receivers: [otlp]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]
 
     traces/forward:
       receivers: [otlp]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observetracing]

--- a/packaging/windows/connections/host_monitoring/host.yaml.tmpl
+++ b/packaging/windows/connections/host_monitoring/host.yaml.tmpl
@@ -8,6 +8,16 @@ receivers:
 service:
   pipelines:
     metrics/agent-filestats:
-       receivers: [filestats/agent]
-       processors: [resourcedetection, resourcedetection/cloud]
-       exporters: [prometheusremotewrite/observe]
+      receivers: [filestats/agent]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [prometheusremotewrite/observe]

--- a/packaging/windows/connections/host_monitoring/host_metrics.yaml.tmpl
+++ b/packaging/windows/connections/host_monitoring/host_metrics.yaml.tmpl
@@ -26,5 +26,15 @@ service:
   pipelines:
     metrics/host_monitoring_host:
       receivers: [hostmetrics/host-monitoring-host]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/windows/connections/host_monitoring/logs.yaml.tmpl
+++ b/packaging/windows/connections/host_monitoring/logs.yaml.tmpl
@@ -18,5 +18,16 @@ service:
   pipelines:
     logs/host_monitoring-windowsevents:
       receivers: [windowseventlog/host_monitoring-application, windowseventlog/host_monitoring-security, windowseventlog/host_monitoring-system]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [otlphttp/observe, count]

--- a/packaging/windows/connections/host_monitoring/process_metrics.yaml.tmpl
+++ b/packaging/windows/connections/host_monitoring/process_metrics.yaml.tmpl
@@ -29,5 +29,15 @@ service:
   pipelines:
     metrics/host_monitoring_process:
       receivers: [hostmetrics/host-monitoring-process]
-      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      processors:
+        - memory_limiter
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
       exporters: [prometheusremotewrite/observe]

--- a/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml.tmpl
+++ b/packaging/windows/connections/self_monitoring/logs_and_metrics.yaml.tmpl
@@ -24,10 +24,33 @@ service:
   pipelines:
     metrics/agent-internal:
       receivers: [prometheus/agent, count]
-      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, deltatocumulative, batch]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - deltatocumulative
+        - batch
       exporters: [prometheusremotewrite/observe]
 
     logs/agent-config:
-       receivers: [filelog/agent-config]
-       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
-       exporters: [otlphttp/observe]
+      receivers: [filelog/agent-config]
+      processors:
+        - memory_limiter
+        - transform/truncate
+        - resourcedetection
+        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        - batch
+      exporters: [otlphttp/observe]


### PR DESCRIPTION
### Description

OB-44816 Add config option to set generic attributes or resource attributes. This is needed to configure service explorer attributes when running on a host.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary