### PR TITLE
feat: add snapshot tests for bundled config

### DIFF
--- a/integration/scripts/requirements.txt
+++ b/integration/scripts/requirements.txt
@@ -1,1 +1,2 @@
 fabric==3.2.2
+pytest-snapshot==0.9.0

--- a/integration/scripts/snapshots/docker.yaml
+++ b/integration/scripts/snapshots/docker.yaml
@@ -1,0 +1,366 @@
+connectors:
+    count: null
+exporters:
+    debug: null
+    nop: null
+    otlphttp/observe:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    otlphttp/observetracing:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Tracing
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    prometheusremotewrite/observe:
+        endpoint: https://123456789.collect.observe-eng.com/v1/prometheus
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        resource_to_telemetry_conversion:
+            enabled: true
+        send_metadata: true
+extensions:
+    file_storage:
+        directory: /var/lib/observe-agent/filestorage
+    health_check:
+        endpoint: localhost:12345
+        path: /test-status
+processors:
+    batch:
+        timeout: 5s
+    deltatocumulative: null
+    filter/count:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, ".*")
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
+    resourcedetection:
+        detectors:
+            - env
+            - system
+        system:
+            hostname_sources:
+                - dns
+                - os
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.cpu.cache.l2.size:
+                    enabled: true
+                host.cpu.family:
+                    enabled: true
+                host.cpu.model.id:
+                    enabled: true
+                host.cpu.model.name:
+                    enabled: true
+                host.cpu.stepping:
+                    enabled: true
+                host.cpu.vendor.id:
+                    enabled: true
+                host.id:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: true
+                os.type:
+                    enabled: true
+    resourcedetection/cloud:
+        detectors:
+            - ec2
+            - test
+        override: false
+        timeout: 2s
+    transform/truncate:
+        log_statements:
+            - context: log
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+        trace_statements:
+            - context: span
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+receivers:
+    filelog/agent-config:
+        include:
+            - /etc/observe-agent/connections/common/base.yaml.tmpl
+        include_file_path: true
+        multiline:
+            line_end_pattern: ENDOFLINEPATTERN
+        poll_interval: 5m
+        start_at: beginning
+    filelog/host_monitoring:
+        exclude:
+            - exclude1
+            - exclude2
+        include:
+            - include1
+            - include2
+        include_file_path: true
+        max_log_size: 4MiB
+        operators:
+            - expr: body matches "otel-contrib"
+              type: filter
+        retry_on_failure:
+            enabled: true
+        storage: file_storage
+    filestats/agent:
+        collection_interval: 5m
+        include: /etc/observe-agent/connections/common/base.yaml.tmpl
+        initial_delay: 60s
+    hostmetrics/host-monitoring-host:
+        collection_interval: 60s
+        root_path: /hostfs
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+            paging:
+                metrics:
+                    system.paging.utilization:
+                        enabled: true
+            processes: null
+    hostmetrics/host-monitoring-process:
+        collection_interval: 60s
+        root_path: /hostfs
+        scrapers:
+            process:
+                metrics:
+                    process.context_switches:
+                        enabled: true
+                    process.cpu.utilization:
+                        enabled: true
+                    process.disk.operations:
+                        enabled: true
+                    process.memory.utilization:
+                        enabled: true
+                    process.open_file_descriptors:
+                        enabled: true
+                    process.paging.faults:
+                        enabled: true
+                    process.signals_pending:
+                        enabled: true
+                    process.threads:
+                        enabled: true
+                mute_process_exe_error: true
+                mute_process_io_error: true
+                mute_process_name_error: true
+                mute_process_user_error: true
+    journald/agent:
+        priority: info
+        units:
+            - observe-agent
+    journald/host_monitoring:
+        priority: info
+        units:
+            - cron
+            - ssh
+            - systemd-networkd
+            - systemd-resolved
+            - systemd-login
+            - multipathd
+            - systemd-user-sessions
+            - ufw
+            - observe-agent
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: localhost:4317
+            http:
+                endpoint: localhost:4318
+    prometheus/agent:
+        config:
+            scrape_configs:
+                - job_name: otelcol
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: .*grpc_io.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+service:
+    extensions:
+        - health_check
+        - file_storage
+    pipelines:
+        logs/agent-config:
+            exporters:
+                - otlphttp/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - filelog/agent-config
+        logs/agent-journald:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - journald/agent
+        logs/forward:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - otlp
+        logs/host_monitoring-file:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - filelog/host_monitoring
+        logs/host_monitoring-journald:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - journald/host_monitoring
+        metrics/agent-filestats:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - filestats/agent
+        metrics/agent-internal:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - prometheus/agent
+                - count
+        metrics/count-nop-in:
+            exporters:
+                - count
+            receivers:
+                - nop
+        metrics/count-nop-out:
+            exporters:
+                - nop
+            receivers:
+                - count
+        metrics/forward:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - otlp
+        metrics/host_monitoring_host:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-host
+        metrics/host_monitoring_process:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-process
+        traces/forward:
+            exporters:
+                - otlphttp/observetracing
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - otlp
+    telemetry:
+        logs:
+            level: ERROR
+        metrics:
+            level: normal
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 0.0.0.0
+                            port: 12346
+

--- a/integration/scripts/snapshots/docker.yaml
+++ b/integration/scripts/snapshots/docker.yaml
@@ -43,6 +43,11 @@ extensions:
         endpoint: localhost:12345
         path: /test-status
 processors:
+    attributes/observe_global_attributes:
+        actions:
+            - action: insert
+              key: test-attr
+              value: test-value
     batch:
         timeout: 5s
     deltatocumulative: null
@@ -51,6 +56,14 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    resource/observe_global_resource_attributes:
+        attributes:
+            - action: insert
+              key: deployment.environment
+              value: test
+            - action: insert
+              key: service.name
+              value: test-service
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
@@ -238,6 +251,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filelog/agent-config
@@ -250,6 +265,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - journald/agent
@@ -260,6 +277,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
             receivers:
                 - otlp
         logs/host_monitoring-file:
@@ -271,6 +290,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filelog/host_monitoring
@@ -283,6 +304,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - journald/host_monitoring
@@ -293,6 +316,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filestats/agent
@@ -304,6 +329,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -325,6 +352,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -336,6 +365,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
@@ -346,6 +377,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-process
@@ -355,6 +388,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
             receivers:
                 - otlp
     telemetry:

--- a/integration/scripts/snapshots/docker.yaml
+++ b/integration/scripts/snapshots/docker.yaml
@@ -30,6 +30,9 @@ exporters:
         headers:
             authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
             x-observe-target-package: Host Explorer
+        max_batch_request_parallelism: 5
+        remote_write_queue:
+            num_consumers: 5
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
@@ -287,8 +290,10 @@ service:
             exporters:
                 - prometheusremotewrite/observe
             processors:
+                - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - batch
             receivers:
                 - filestats/agent
         metrics/agent-internal:

--- a/integration/scripts/snapshots/docker.yaml
+++ b/integration/scripts/snapshots/docker.yaml
@@ -37,6 +37,9 @@ exporters:
             enabled: true
         send_metadata: true
 extensions:
+    cgroupruntime:
+        gomaxprocs:
+            enabled: true
     file_storage:
         directory: /var/lib/observe-agent/filestorage
     health_check:
@@ -56,6 +59,10 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
     resource/observe_global_resource_attributes:
         attributes:
             - action: insert
@@ -64,10 +71,6 @@ processors:
             - action: insert
               key: service.name
               value: test-service
-    memory_limiter:
-        check_interval: 1s
-        limit_percentage: 80
-        spike_limit_percentage: 20
     resourcedetection:
         detectors:
             - env
@@ -242,6 +245,7 @@ service:
     extensions:
         - health_check
         - file_storage
+        - cgroupruntime
     pipelines:
         logs/agent-config:
             exporters:

--- a/integration/scripts/snapshots/full-agent-config.yaml
+++ b/integration/scripts/snapshots/full-agent-config.yaml
@@ -1,0 +1,48 @@
+cloud_resource_detectors:
+    - ec2
+    - test
+
+# Debug mode - Sets agent log level to debug
+debug: true
+
+forwarding:
+    enabled: true
+
+health_check:
+    enabled: true
+    endpoint: localhost:12345
+    path: /test-status
+
+host_monitoring:
+    enabled: true
+    logs:
+        enabled: true
+        exclude: [exclude1, exclude2]
+        include: [include1, include2]
+    metrics:
+        host:
+            enabled: true
+        process:
+            enabled: true
+
+internal_telemetry:
+    enabled: true
+    logs:
+        enabled: true
+        level: ERROR
+    metrics:
+        enabled: true
+        host: 0.0.0.0
+        level: normal
+        port: 12346
+
+# Target Observe collection url
+observe_url: https://123456789.collect.observe-eng.com/
+
+otel_config_overrides: {}
+
+self_monitoring:
+    enabled: true
+
+# Observe data token
+token: abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl

--- a/integration/scripts/snapshots/full-agent-config.yaml
+++ b/integration/scripts/snapshots/full-agent-config.yaml
@@ -1,3 +1,9 @@
+# Target Observe collection url
+observe_url: https://123456789.collect.observe-eng.com/
+
+# Observe data token
+token: abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+
 cloud_resource_detectors:
     - ec2
     - test
@@ -5,13 +11,31 @@ cloud_resource_detectors:
 # Debug mode - Sets agent log level to debug
 debug: true
 
-forwarding:
-    enabled: true
+attributes:
+    test-attr: test-value
+
+resource_attributes:
+    service.name: test-service
+    deployment.environment: test
 
 health_check:
     enabled: true
     endpoint: localhost:12345
     path: /test-status
+
+internal_telemetry:
+    enabled: true
+    logs:
+        enabled: true
+        level: ERROR
+    metrics:
+        enabled: true
+        host: 0.0.0.0
+        level: normal
+        port: 12346
+
+forwarding:
+    enabled: true
 
 host_monitoring:
     enabled: true
@@ -25,24 +49,7 @@ host_monitoring:
         process:
             enabled: true
 
-internal_telemetry:
-    enabled: true
-    logs:
-        enabled: true
-        level: ERROR
-    metrics:
-        enabled: true
-        host: 0.0.0.0
-        level: normal
-        port: 12346
-
-# Target Observe collection url
-observe_url: https://123456789.collect.observe-eng.com/
-
-otel_config_overrides: {}
-
 self_monitoring:
     enabled: true
 
-# Observe data token
-token: abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+otel_config_overrides: {}

--- a/integration/scripts/snapshots/linux.yaml
+++ b/integration/scripts/snapshots/linux.yaml
@@ -1,0 +1,364 @@
+connectors:
+    count: null
+exporters:
+    debug: null
+    nop: null
+    otlphttp/observe:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    otlphttp/observetracing:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Tracing
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    prometheusremotewrite/observe:
+        endpoint: https://123456789.collect.observe-eng.com/v1/prometheus
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        resource_to_telemetry_conversion:
+            enabled: true
+        send_metadata: true
+extensions:
+    file_storage:
+        directory: /var/lib/observe-agent/filestorage
+    health_check:
+        endpoint: localhost:12345
+        path: /test-status
+processors:
+    batch:
+        timeout: 5s
+    deltatocumulative: null
+    filter/count:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, ".*")
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
+    resourcedetection:
+        detectors:
+            - env
+            - system
+        system:
+            hostname_sources:
+                - dns
+                - os
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.cpu.cache.l2.size:
+                    enabled: true
+                host.cpu.family:
+                    enabled: true
+                host.cpu.model.id:
+                    enabled: true
+                host.cpu.model.name:
+                    enabled: true
+                host.cpu.stepping:
+                    enabled: true
+                host.cpu.vendor.id:
+                    enabled: true
+                host.id:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.description:
+                    enabled: true
+                os.type:
+                    enabled: true
+    resourcedetection/cloud:
+        detectors:
+            - ec2
+            - test
+        override: false
+        timeout: 2s
+    transform/truncate:
+        log_statements:
+            - context: log
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+        trace_statements:
+            - context: span
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+receivers:
+    filelog/agent-config:
+        include:
+            - /etc/observe-agent/connections/common/base.yaml.tmpl
+        include_file_path: true
+        multiline:
+            line_end_pattern: ENDOFLINEPATTERN
+        poll_interval: 5m
+        start_at: beginning
+    filelog/host_monitoring:
+        exclude:
+            - exclude1
+            - exclude2
+        include:
+            - include1
+            - include2
+        include_file_path: true
+        max_log_size: 4MiB
+        operators:
+            - expr: body matches "otel-contrib"
+              type: filter
+        retry_on_failure:
+            enabled: true
+        storage: file_storage
+    filestats/agent:
+        collection_interval: 5m
+        include: /etc/observe-agent/connections/common/base.yaml.tmpl
+        initial_delay: 60s
+    hostmetrics/host-monitoring-host:
+        collection_interval: 60s
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.frequency:
+                        enabled: true
+                    system.cpu.logical.count:
+                        enabled: true
+                    system.cpu.physical.count:
+                        enabled: true
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.linux.memory.available:
+                        enabled: true
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+            paging:
+                metrics:
+                    system.paging.utilization:
+                        enabled: true
+            processes: null
+    hostmetrics/host-monitoring-process:
+        collection_interval: 60s
+        scrapers:
+            process:
+                metrics:
+                    process.context_switches:
+                        enabled: true
+                    process.cpu.utilization:
+                        enabled: true
+                    process.disk.operations:
+                        enabled: true
+                    process.memory.utilization:
+                        enabled: true
+                    process.open_file_descriptors:
+                        enabled: true
+                    process.paging.faults:
+                        enabled: true
+                    process.signals_pending:
+                        enabled: true
+                    process.threads:
+                        enabled: true
+                mute_process_exe_error: true
+                mute_process_io_error: true
+                mute_process_name_error: true
+                mute_process_user_error: true
+    journald/agent:
+        priority: info
+        units:
+            - observe-agent
+    journald/host_monitoring:
+        priority: info
+        units:
+            - cron
+            - ssh
+            - systemd-networkd
+            - systemd-resolved
+            - systemd-login
+            - multipathd
+            - systemd-user-sessions
+            - ufw
+            - observe-agent
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: localhost:4317
+            http:
+                endpoint: localhost:4318
+    prometheus/agent:
+        config:
+            scrape_configs:
+                - job_name: otelcol
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: .*grpc_io.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+service:
+    extensions:
+        - health_check
+        - file_storage
+    pipelines:
+        logs/agent-config:
+            exporters:
+                - otlphttp/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - filelog/agent-config
+        logs/agent-journald:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - journald/agent
+        logs/forward:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - otlp
+        logs/host_monitoring-file:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - filelog/host_monitoring
+        logs/host_monitoring-journald:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - journald/host_monitoring
+        metrics/agent-filestats:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - filestats/agent
+        metrics/agent-internal:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - prometheus/agent
+                - count
+        metrics/count-nop-in:
+            exporters:
+                - count
+            receivers:
+                - nop
+        metrics/count-nop-out:
+            exporters:
+                - nop
+            receivers:
+                - count
+        metrics/forward:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - otlp
+        metrics/host_monitoring_host:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-host
+        metrics/host_monitoring_process:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-process
+        traces/forward:
+            exporters:
+                - otlphttp/observetracing
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - otlp
+    telemetry:
+        logs:
+            level: ERROR
+        metrics:
+            level: normal
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 0.0.0.0
+                            port: 12346
+

--- a/integration/scripts/snapshots/linux.yaml
+++ b/integration/scripts/snapshots/linux.yaml
@@ -30,6 +30,9 @@ exporters:
         headers:
             authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
             x-observe-target-package: Host Explorer
+        max_batch_request_parallelism: 5
+        remote_write_queue:
+            num_consumers: 5
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
@@ -285,8 +288,10 @@ service:
             exporters:
                 - prometheusremotewrite/observe
             processors:
+                - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - batch
             receivers:
                 - filestats/agent
         metrics/agent-internal:

--- a/integration/scripts/snapshots/linux.yaml
+++ b/integration/scripts/snapshots/linux.yaml
@@ -43,6 +43,11 @@ extensions:
         endpoint: localhost:12345
         path: /test-status
 processors:
+    attributes/observe_global_attributes:
+        actions:
+            - action: insert
+              key: test-attr
+              value: test-value
     batch:
         timeout: 5s
     deltatocumulative: null
@@ -55,6 +60,14 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
+    resource/observe_global_resource_attributes:
+        attributes:
+            - action: insert
+              key: deployment.environment
+              value: test
+            - action: insert
+              key: service.name
+              value: test-service
     resourcedetection:
         detectors:
             - env
@@ -236,6 +249,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filelog/agent-config
@@ -248,6 +263,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - journald/agent
@@ -258,6 +275,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
             receivers:
                 - otlp
         logs/host_monitoring-file:
@@ -269,6 +288,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filelog/host_monitoring
@@ -281,6 +302,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - journald/host_monitoring
@@ -291,6 +314,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filestats/agent
@@ -302,6 +327,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -323,6 +350,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -334,6 +363,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
@@ -344,6 +375,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-process
@@ -353,6 +386,8 @@ service:
             processors:
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
             receivers:
                 - otlp
     telemetry:

--- a/integration/scripts/snapshots/windows.yaml
+++ b/integration/scripts/snapshots/windows.yaml
@@ -43,6 +43,11 @@ extensions:
         endpoint: localhost:12345
         path: /test-status
 processors:
+    attributes/observe_global_attributes:
+        actions:
+            - action: insert
+              key: test-attr
+              value: test-value
     batch:
         timeout: 5s
     deltatocumulative: null
@@ -51,6 +56,14 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    resource/observe_global_resource_attributes:
+        attributes:
+            - action: insert
+              key: deployment.environment
+              value: test
+            - action: insert
+              key: service.name
+              value: test-service
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
@@ -187,6 +200,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filelog/agent-config
@@ -199,6 +214,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - otlp
@@ -211,6 +228,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - windowseventlog/host_monitoring-application
@@ -223,6 +242,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - filestats/agent
@@ -234,6 +255,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -257,6 +280,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - deltatocumulative
                 - batch
             receivers:
@@ -268,6 +293,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
@@ -278,6 +305,8 @@ service:
                 - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-process
@@ -289,6 +318,8 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - otlp

--- a/integration/scripts/snapshots/windows.yaml
+++ b/integration/scripts/snapshots/windows.yaml
@@ -56,6 +56,10 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
     resource/observe_global_resource_attributes:
         attributes:
             - action: insert
@@ -64,10 +68,6 @@ processors:
             - action: insert
               key: service.name
               value: test-service
-    memory_limiter:
-        check_interval: 1s
-        limit_percentage: 80
-        spike_limit_percentage: 20
     resourcedetection:
         detectors:
             - env

--- a/integration/scripts/snapshots/windows.yaml
+++ b/integration/scripts/snapshots/windows.yaml
@@ -1,0 +1,301 @@
+connectors:
+    count: null
+exporters:
+    debug: null
+    nop: null
+    otlphttp/observe:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    otlphttp/observetracing:
+        compression: zstd
+        endpoint: https://123456789.collect.observe-eng.com/v2/otel
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Tracing
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
+    prometheusremotewrite/observe:
+        endpoint: https://123456789.collect.observe-eng.com/v1/prometheus
+        headers:
+            authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            x-observe-target-package: Host Explorer
+        resource_to_telemetry_conversion:
+            enabled: true
+        send_metadata: true
+extensions:
+    file_storage:
+        directory: C:\ProgramData\Observe\observe-agent\filestorage
+    health_check:
+        endpoint: localhost:12345
+        path: /test-status
+processors:
+    batch:
+        timeout: 5s
+    deltatocumulative: null
+    filter/count:
+        error_mode: ignore
+        metrics:
+            metric:
+                - IsMatch(name, ".*")
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
+    resourcedetection:
+        detectors:
+            - env
+            - system
+        system:
+            hostname_sources:
+                - os
+            resource_attributes:
+                host.id:
+                    enabled: true
+    resourcedetection/cloud:
+        detectors:
+            - ec2
+            - test
+        override: false
+        timeout: 2s
+    transform/truncate:
+        log_statements:
+            - context: log
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+        trace_statements:
+            - context: span
+              statements:
+                - truncate_all(attributes, 4095)
+                - truncate_all(resource.attributes, 4095)
+receivers:
+    filelog/agent-config:
+        include:
+            - C:\Program Files\Observe\observe-agent\connections\common\base.yaml.tmpl
+        include_file_path: true
+        multiline:
+            line_end_pattern: ENDOFLINEPATTERN
+        poll_interval: 5m
+        start_at: beginning
+    filestats/agent:
+        collection_interval: 5m
+        include: C:\Program Files\Observe\observe-agent\connections\common\base.yaml.tmpl
+        initial_delay: 60s
+    hostmetrics/host-monitoring-host:
+        collection_interval: 60s
+        scrapers:
+            cpu:
+                metrics:
+                    system.cpu.utilization:
+                        enabled: true
+            disk: null
+            filesystem:
+                metrics:
+                    system.filesystem.utilization:
+                        enabled: true
+            load: null
+            memory:
+                metrics:
+                    system.memory.utilization:
+                        enabled: true
+            network: null
+            paging:
+                metrics:
+                    system.paging.utilization:
+                        enabled: true
+    hostmetrics/host-monitoring-process:
+        collection_interval: 60s
+        scrapers:
+            process:
+                metrics:
+                    process.context_switches:
+                        enabled: true
+                    process.cpu.utilization:
+                        enabled: true
+                    process.disk.operations:
+                        enabled: true
+                    process.memory.utilization:
+                        enabled: true
+                    process.open_file_descriptors:
+                        enabled: true
+                    process.paging.faults:
+                        enabled: true
+                    process.signals_pending:
+                        enabled: true
+                    process.threads:
+                        enabled: true
+                mute_process_exe_error: true
+                mute_process_io_error: true
+                mute_process_name_error: true
+                mute_process_user_error: true
+    nop: null
+    otlp:
+        protocols:
+            grpc:
+                endpoint: localhost:4317
+            http:
+                endpoint: localhost:4318
+    prometheus/agent:
+        config:
+            scrape_configs:
+                - job_name: otelcol
+                  metric_relabel_configs:
+                    - action: drop
+                      regex: .*grpc_io.*
+                      source_labels:
+                        - __name__
+                  scrape_interval: 10s
+                  static_configs:
+                    - targets:
+                        - 0.0.0.0:8888
+    windowseventlog/host_monitoring-application:
+        channel: Application
+        retry_on_failure:
+            enabled: true
+    windowseventlog/host_monitoring-security:
+        channel: Security
+        retry_on_failure:
+            enabled: true
+    windowseventlog/host_monitoring-system:
+        channel: System
+        retry_on_failure:
+            enabled: true
+service:
+    extensions:
+        - health_check
+        - file_storage
+    pipelines:
+        logs/agent-config:
+            exporters:
+                - otlphttp/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - filelog/agent-config
+        logs/forward:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - otlp
+        logs/host_monitoring-windowsevents:
+            exporters:
+                - otlphttp/observe
+                - count
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - windowseventlog/host_monitoring-application
+                - windowseventlog/host_monitoring-security
+                - windowseventlog/host_monitoring-system
+        metrics/agent-filestats:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+            receivers:
+                - filestats/agent
+        metrics/agent-internal:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - prometheus/agent
+                - count
+        metrics/count-nop-in:
+            exporters:
+                - count
+            receivers:
+                - nop
+        metrics/count-nop-out:
+            exporters:
+                - nop
+            receivers:
+                - count
+        metrics/forward:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - deltatocumulative
+                - batch
+            receivers:
+                - otlp
+        metrics/host_monitoring_host:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-host
+        metrics/host_monitoring_process:
+            exporters:
+                - prometheusremotewrite/observe
+            processors:
+                - memory_limiter
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - hostmetrics/host-monitoring-process
+        traces/forward:
+            exporters:
+                - otlphttp/observetracing
+            processors:
+                - memory_limiter
+                - transform/truncate
+                - resourcedetection
+                - resourcedetection/cloud
+                - batch
+            receivers:
+                - otlp
+    telemetry:
+        logs:
+            level: ERROR
+        metrics:
+            level: normal
+            readers:
+                - pull:
+                    exporter:
+                        prometheus:
+                            host: 0.0.0.0
+                            port: 12346
+

--- a/integration/scripts/snapshots/windows.yaml
+++ b/integration/scripts/snapshots/windows.yaml
@@ -30,6 +30,9 @@ exporters:
         headers:
             authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
             x-observe-target-package: Host Explorer
+        max_batch_request_parallelism: 5
+        remote_write_queue:
+            num_consumers: 5
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
@@ -217,8 +220,10 @@ service:
             exporters:
                 - prometheusremotewrite/observe
             processors:
+                - memory_limiter
                 - resourcedetection
                 - resourcedetection/cloud
+                - batch
             receivers:
                 - filestats/agent
         metrics/agent-internal:

--- a/integration/scripts/test_snapshot_conf.py
+++ b/integration/scripts/test_snapshot_conf.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import utils as u
+import os
+import difflib
+
+AGENT_CONFIG_FILE_NAME = "full-agent-config.yaml"
+
+
+def upload_agent_config(remote_host: u.Host, remote_path: str) -> None:
+    current_script_dir = os.path.dirname(os.path.abspath(__file__))
+    # Upload the full observe-agent config to remote host
+    local_path = os.path.abspath(
+        os.path.join(current_script_dir, "snapshots", AGENT_CONFIG_FILE_NAME)
+    )
+    print(f"Path to '{AGENT_CONFIG_FILE_NAME}' file: {local_path}")
+    remote_host.put_file(local_path=local_path, remote_path=remote_path)
+
+
+def do_snapshot_test(
+    remote_host: u.Host, remote_path: str, config_command: str, snapshot_file: str
+) -> None:
+    # Copy the agent config to the remote host
+    upload_agent_config(remote_host, remote_path)
+    result = remote_host.run_command(config_command)
+    if result.exited != 0 or result.stderr:
+        u.print_remote_result(result)
+        raise ValueError(f"❌ Error in rendering config for {snapshot_file}")
+    rendered_config = result.stdout
+    current_script_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(current_script_dir, "snapshots", snapshot_file), "r") as f:
+        expected_config = f.read()
+    if rendered_config == expected_config:
+        print(f" ✅ Config match for {snapshot_file}")
+        return
+    diff = difflib.Differ().compare(
+        expected_config.splitlines(), rendered_config.splitlines()
+    )
+    print(f"Diff expected vs actual for {snapshot_file}:")
+    print("\n".join(diff))
+    raise ValueError(f"❌ Config mismatch for {snapshot_file}")
+
+
+@u.print_test_decorator
+def run_test_windows(remote_host: u.Host, env_vars: dict) -> None:
+    user = env_vars["user"]
+    remote_path = f"/C:/Users/{user}"  # for user in sftp
+    config_command = f"Set-Location \"C:\\Program Files\\Observe\\observe-agent\"; ./observe-agent --observe-config C:\\Users\\{user}\\{AGENT_CONFIG_FILE_NAME} config --render-otel"
+    snapshot_file = "windows.yaml"
+    do_snapshot_test(remote_host, remote_path, config_command, snapshot_file)
+
+
+@u.print_test_decorator
+def run_test_docker(remote_host: u.Host, env_vars: dict) -> None:
+    docker_prefix = u.get_docker_prefix(
+        remote_host,
+        False,
+        extra_args=f"--mount type=bind,source=$(pwd)/{AGENT_CONFIG_FILE_NAME},target=/etc/observe-agent/{AGENT_CONFIG_FILE_NAME}",
+    )
+    remote_path = "/home/" + env_vars["user"]
+    config_command = f"{docker_prefix} --observe-config /etc/observe-agent/{AGENT_CONFIG_FILE_NAME} config --render-otel"
+    snapshot_file = "docker.yaml"
+    do_snapshot_test(remote_host, remote_path, config_command, snapshot_file)
+
+
+@u.print_test_decorator
+def run_test_linux(remote_host: u.Host, env_vars: dict) -> None:
+    remote_path = "/home/" + env_vars["user"]
+    config_command = f"observe-agent --observe-config {remote_path}/{AGENT_CONFIG_FILE_NAME} config --render-otel"
+    snapshot_file = "linux.yaml"
+    do_snapshot_test(remote_host, remote_path, config_command, snapshot_file)
+
+
+if __name__ == "__main__":
+    env_vars = u.get_env_vars()
+    remote_host = u.Host(
+        host_ip=env_vars["host"],
+        username=env_vars["user"],
+        key_file_path=env_vars["key_filename"],
+        password=env_vars["password"],
+    )
+
+    # Test SSH Connection before starting test of interest
+    remote_host.test_conection(int(env_vars["machine_config"]["sleep"]))
+
+    if (
+        "redhat" in env_vars["machine_config"]["distribution"]
+        or "debian" in env_vars["machine_config"]["distribution"]
+    ):
+        run_test_linux(remote_host, env_vars)
+    elif "windows" in env_vars["machine_config"]["distribution"]:
+        run_test_windows(remote_host, env_vars)
+    elif "docker" in env_vars["machine_config"]["distribution"]:
+        run_test_docker(remote_host, env_vars)

--- a/integration/scripts/utils.py
+++ b/integration/scripts/utils.py
@@ -263,7 +263,7 @@ def get_docker_image(remote_host: Host) -> str:
     return images[0]
 
 
-def get_docker_prefix(remote_host: Host, detach: bool) -> str:
+def get_docker_prefix(remote_host: Host, detach: bool, extra_args: str = "") -> str:
     image = get_docker_image(remote_host)
     return f'sudo docker run {"-d --restart on-failure" if detach else ""} \
         --mount type=bind,source=/proc,target=/hostfs/proc,readonly \
@@ -273,6 +273,7 @@ def get_docker_prefix(remote_host: Host, detach: bool) -> str:
         --mount type=bind,source=/var/log,target=/hostfs/var/log,readonly \
         --mount type=bind,source=/var/lib/docker/containers,target=/var/lib/docker/containers,readonly \
         --mount type=bind,source=$(pwd)/observe-agent.yaml,target=/etc/observe-agent/observe-agent.yaml \
+        {extra_args} \
         --pid host {image}'
 
 

--- a/integration/tests/integration.tftest.hcl
+++ b/integration/tests/integration.tftest.hcl
@@ -89,6 +89,30 @@ run "test_version" {
   }
 }
 
+run "test_snapshot_conf" {
+  module {
+    source  = "observeinc/collection/aws//modules/testing/exec"
+    version = "2.9.0"
+  }
+
+  variables {
+    command = "python3 ./scripts/test_snapshot_conf.py"
+    env_vars = {
+      HOST           = run.setup_ec2.public_ip
+      USER           = run.setup_ec2.user_name
+      KEY_FILENAME   = run.setup_ec2.private_key_path
+      PASSWORD       = run.setup_ec2.password
+      MACHINE_NAME   = run.setup_ec2.machine_name
+      MACHINE_CONFIG = run.setup_ec2.machine_config
+    }
+  }
+
+  assert {
+    condition     = output.error == ""
+    error_message = "Error in Snapshot Test"
+  }
+}
+
 
 run "test_configure" {
   module {

--- a/packaging/docker/observe-agent/connections/common/forward.yaml.tmpl
+++ b/packaging/docker/observe-agent/connections/common/forward.yaml.tmpl
@@ -26,13 +26,13 @@ service:
       processors:
         - resourcedetection
         - resourcedetection/cloud
-        - deltatocumulative
         {{- if .HasAttributes }}
         - attributes/observe_global_attributes
         {{- end }}
         {{- if .HasResourceAttributes }}
         - resource/observe_global_resource_attributes
         {{- end }}
+        - deltatocumulative
         - batch
       exporters: [prometheusremotewrite/observe]
 


### PR DESCRIPTION
### Description

OB-45143 Add snapshot tests for the full bundled config in our test environments. This will catch when the observe-agent's provided otel config changes.

### Checklist
- [x] Created tests which fail without the change (if possible)