### PR TITLE
fix: bump goreleaser version and add explicit timeout to the release workflow

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -22,7 +22,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.8.2
+          version: 2.9.0
           args: changelog
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: build --snapshot --id=linux_build --skip=validate --single-target
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -29,10 +29,11 @@ jobs:
       - name: Install qemu
         uses: docker/setup-qemu-action@v3
       - name: Run GoReleaser
+        timeout-minutes: 15
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: release --prepare --clean --snapshot --verbose
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: release --clean --skip=validate --verbose --nightly --parallelism 6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,11 +56,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run GoReleaser
+        timeout-minutes: 15
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
           # 'latest', 'nightly', or a semver
-          version: 2.8.2
+          version: 2.9.0
           args: release --clean --skip=validate --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: release --prepare --clean --snapshot --verbose --parallelism 6
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/vuln-check-full.yaml
+++ b/.github/workflows/vuln-check-full.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: build --snapshot --id=linux_build --skip=validate --single-target
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/vuln-check-release.yaml
+++ b/.github/workflows/vuln-check-release.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: 2.8.2
+          version: 2.9.0
           args: build --snapshot --id=linux_build --skip=validate --single-target
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
The latest release was canceled; this same timeout has been working for integration tests and nightly builds.