### PR TITLE
feat: add the yaml schema comment to our default agent configs and init-config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -195,6 +195,7 @@ release:
   # Add all install scripts to the release
   extra_files:
     - "./scripts/*install*"
+    - "./observe-agent.schema.json"
 
 dockers:
   - image_templates:

--- a/internal/commands/initconfig/writeconfigfile.go
+++ b/internal/commands/initconfig/writeconfigfile.go
@@ -69,6 +69,9 @@ func writeConfigFile(f *os.File, agentConfig *config.AgentConfig, includeAllOpti
 		yamlStr += "\n" + strings.Trim(otelOverrideSection, " \n\t\r") + "\n"
 	}
 
+	// Add the latest schema comment at the top.
+	yamlStr = "# yaml-language-server: $schema=https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent.schema.json\n\n" + yamlStr
+
 	_, err = f.WriteString(yamlStr)
 	return err
 }

--- a/packaging/linux/config/observe-agent.yaml
+++ b/packaging/linux/config/observe-agent.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent.schema.json
+
 # Observe data token
 token: "<OBSERVE TOKEN>"
 

--- a/packaging/windows/observe-agent.yaml
+++ b/packaging/windows/observe-agent.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://github.com/observeinc/observe-agent/releases/latest/download/observe-agent.schema.json
+
 # Observe data token
 token: "${OBSERVE_TOKEN}"
 


### PR DESCRIPTION
### Description

IDEs check this to enforce yaml schema. I think that it is safe to release the schema for the first time in the same release that we set this comment, since the comment will not be in use until the schema is released.