### PR TITLE
feat: add log encoding config option for internal telemetry

### DIFF
--- a/internal/commands/config/test/snap0-default-agent-config.yaml
+++ b/internal/commands/config/test/snap0-default-agent-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../observe-agent.schema.json
 # Target Observe collection url
 observe_url: https://123456789.collect.observe-eng.com/
 

--- a/internal/commands/config/test/snap0-docker-output.yaml
+++ b/internal/commands/config/test/snap0-docker-output.yaml
@@ -329,6 +329,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: console
             level: INFO
         metrics:
             level: detailed

--- a/internal/commands/config/test/snap0-linux-output.yaml
+++ b/internal/commands/config/test/snap0-linux-output.yaml
@@ -324,6 +324,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: console
             level: INFO
         metrics:
             level: detailed

--- a/internal/commands/config/test/snap0-macos-output.yaml
+++ b/internal/commands/config/test/snap0-macos-output.yaml
@@ -286,6 +286,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: console
             level: INFO
         metrics:
             level: detailed

--- a/internal/commands/config/test/snap0-windows-output.yaml
+++ b/internal/commands/config/test/snap0-windows-output.yaml
@@ -256,6 +256,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: console
             level: INFO
         metrics:
             level: detailed

--- a/internal/commands/config/test/snap1-docker-output.yaml
+++ b/internal/commands/config/test/snap1-docker-output.yaml
@@ -404,6 +404,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: json
             level: ERROR
         metrics:
             level: normal

--- a/internal/commands/config/test/snap1-full-agent-config.yaml
+++ b/internal/commands/config/test/snap1-full-agent-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../observe-agent.schema.json
 # Target Observe collection url
 observe_url: https://123456789.collect.observe-eng.com/
 
@@ -28,6 +29,7 @@ internal_telemetry:
     logs:
         enabled: true
         level: ERROR
+        encoding: json
     metrics:
         enabled: true
         host: 0.0.0.0

--- a/internal/commands/config/test/snap1-linux-output.yaml
+++ b/internal/commands/config/test/snap1-linux-output.yaml
@@ -398,6 +398,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: json
             level: ERROR
         metrics:
             level: normal

--- a/internal/commands/config/test/snap1-macos-output.yaml
+++ b/internal/commands/config/test/snap1-macos-output.yaml
@@ -357,6 +357,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: json
             level: ERROR
         metrics:
             level: normal

--- a/internal/commands/config/test/snap1-windows-output.yaml
+++ b/internal/commands/config/test/snap1-windows-output.yaml
@@ -352,6 +352,7 @@ service:
                 - otlp
     telemetry:
         logs:
+            encoding: json
             level: ERROR
         metrics:
             level: normal

--- a/internal/commands/config/test/snap2-empty-agent-config.yaml
+++ b/internal/commands/config/test/snap2-empty-agent-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../observe-agent.schema.json
 # Target Observe collection url
 observe_url: https://test.collect.observeinc.com/
 

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -68,8 +68,9 @@ type InternalTelemetryMetricsConfig struct {
 }
 
 type InternalTelemetryLogsConfig struct {
-	Enabled bool   `yaml:"enabled" mapstructure:"enabled" default:"true"`
-	Level   string `yaml:"level" mapstructure:"level" default:"${env:OTEL_LOG_LEVEL}"`
+	Enabled  bool   `yaml:"enabled" mapstructure:"enabled" default:"true"`
+	Level    string `yaml:"level" mapstructure:"level" default:"${env:OTEL_LOG_LEVEL}"`
+	Encoding string `yaml:"encoding" mapstructure:"encoding" default:"console" jsonschema:"pattern=^(console|json)$"`
 }
 
 type InternalTelemetryConfig struct {

--- a/internal/connections/bundledconfig/shared/common/internal_telemetry.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/common/internal_telemetry.yaml.tmpl
@@ -13,4 +13,5 @@ service:
     {{- if .InternalTelemetry.Logs.Enabled }}
     logs:
       level: {{ .InternalTelemetry.Logs.Level }}
+      encoding: {{ .InternalTelemetry.Logs.Encoding }}
     {{- end }}

--- a/observe-agent.schema.json
+++ b/observe-agent.schema.json
@@ -182,6 +182,10 @@
         "enabled": {
           "type": "boolean"
         },
+        "encoding": {
+          "pattern": "^(console|json)$",
+          "type": "string"
+        },
         "level": {
           "type": "string"
         }


### PR DESCRIPTION
This is the last internal telemetry option configurable in the helm chart but not in the agent (it's `agent.config.global.service.telemetry.loggingEncoding` in our helm chart).