### PR TITLE
fix: improve naming of RED metric attributes

### DIFF
--- a/internal/commands/config/test/snap0-docker-output.yaml
+++ b/internal/commands/config/test/snap0-docker-output.yaml
@@ -122,11 +122,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap0-linux-output.yaml
+++ b/internal/commands/config/test/snap0-linux-output.yaml
@@ -119,11 +119,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap0-macos-output.yaml
+++ b/internal/commands/config/test/snap0-macos-output.yaml
@@ -119,11 +119,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap0-windows-output.yaml
+++ b/internal/commands/config/test/snap0-windows-output.yaml
@@ -98,11 +98,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap1-docker-output.yaml
+++ b/internal/commands/config/test/snap1-docker-output.yaml
@@ -8,8 +8,8 @@ connectors:
             - name: deployment.environment
             - name: peer.db.name
             - name: peer.messaging.system
-            - name: status.message
-            - name: status_code
+            - name: otel.status_description
+            - name: observe.status_code
         histogram:
             exponential:
                 max_size: 100
@@ -163,11 +163,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/fix_peer_attributes:
         error_mode: ignore
         metric_statements:
@@ -178,7 +178,8 @@ processors:
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
-            - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
@@ -190,7 +191,7 @@ processors:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
             - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
-            - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap1-linux-output.yaml
+++ b/internal/commands/config/test/snap1-linux-output.yaml
@@ -8,8 +8,8 @@ connectors:
             - name: deployment.environment
             - name: peer.db.name
             - name: peer.messaging.system
-            - name: status.message
-            - name: status_code
+            - name: otel.status_description
+            - name: observe.status_code
         histogram:
             exponential:
                 max_size: 100
@@ -160,11 +160,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/fix_peer_attributes:
         error_mode: ignore
         metric_statements:
@@ -175,7 +175,8 @@ processors:
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
-            - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
@@ -187,7 +188,7 @@ processors:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
             - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
-            - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap1-macos-output.yaml
+++ b/internal/commands/config/test/snap1-macos-output.yaml
@@ -8,8 +8,8 @@ connectors:
             - name: deployment.environment
             - name: peer.db.name
             - name: peer.messaging.system
-            - name: status.message
-            - name: status_code
+            - name: otel.status_description
+            - name: observe.status_code
         histogram:
             exponential:
                 max_size: 100
@@ -160,11 +160,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/fix_peer_attributes:
         error_mode: ignore
         metric_statements:
@@ -175,7 +175,8 @@ processors:
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
-            - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
@@ -187,7 +188,7 @@ processors:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
             - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
-            - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/commands/config/test/snap1-windows-output.yaml
+++ b/internal/commands/config/test/snap1-windows-output.yaml
@@ -8,8 +8,8 @@ connectors:
             - name: deployment.environment
             - name: peer.db.name
             - name: peer.messaging.system
-            - name: status.message
-            - name: status_code
+            - name: otel.status_description
+            - name: observe.status_code
         histogram:
             exponential:
                 max_size: 100
@@ -139,11 +139,11 @@ processors:
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-            - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+            - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
     transform/fix_peer_attributes:
         error_mode: ignore
         metric_statements:
@@ -154,7 +154,8 @@ processors:
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
-            - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
@@ -166,7 +167,7 @@ processors:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
             - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
-            - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log

--- a/internal/connections/bundledconfig/shared/application/RED_metrics.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/application/RED_metrics.yaml.tmpl
@@ -12,8 +12,8 @@ connectors:
       - name: deployment.environment
       - name: peer.db.name
       - name: peer.messaging.system
-      - name: status.message
-      - name: status_code
+      - name: otel.status_description
+      - name: observe.status_code
 
 processors:
   # This handles schema normalization as well as moving status to attributes so it can be a dimension in spanmetrics
@@ -26,7 +26,7 @@ processors:
       # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
       - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
       # Needed because `spanmetrics` connector can only operate on attributes or resource attributes.
-      - set(span.attributes["status.message"], span.status.message) where span.status.message != ""
+      - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
 
   # This regroups the metrics by the peer attributes so we can remove `service.name` from the resource when these metric attributes are present
   # NB: these will be deleted from the metric attributes and added to the resource.
@@ -69,7 +69,8 @@ processors:
       - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment)")
 
       # Rename status.code to response_status to be consistent with Trace Explorer and disambiguate from status_code (with an underscore).
-      - set(datapoint.attributes["response_status"], datapoint.attributes["status.code"])
+      - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+      - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
       - delete_key(datapoint.attributes, "status.code")
 
 service:

--- a/internal/connections/bundledconfig/shared/common/forward.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/common/forward.yaml.tmpl
@@ -10,11 +10,11 @@ processors:
   transform/add_span_status_code:
     error_mode: ignore
     trace_statements:
-      - set(span.attributes["status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
-      - set(span.attributes["status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
-      - set(span.attributes["status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
-      - set(span.attributes["status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
-      - set(span.attributes["status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
+      - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.grpc.status_code"] != nil
+      - set(span.attributes["observe.status_code"], Int(span.attributes["grpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["grpc.status_code"] != nil
+      - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["status_code"] == nil and span.attributes["rpc.status_code"] != nil
+      - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.status_code"] != nil
+      - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["status_code"] == nil and span.attributes["http.response.status_code"] != nil
 
   # Always add service.name, service.namespace, and deployment.environment to the resource attributes.
   resource/add_empty_service_attributes:


### PR DESCRIPTION
Renamed attributes:
- `attributes[response_status]` —> `attributes[otel.status_code]` Semconv: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-status-code
- `attributes[status.message]` —> `attributes[otel.status_description]` Semconv: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-status-description
- `attributes[status_code]` —> `attributes[observe.status_code]` (no semconv, this is custom)

Helm Chart PR: https://github.com/observeinc/helm-charts/pull/406