### PR TITLE
fix: use env as default config resolve schema

### DIFF
--- a/internal/commands/config/config_test.go
+++ b/internal/commands/config/config_test.go
@@ -149,7 +149,8 @@ func runSnapshotTest(t *testing.T, test snapshotTest) {
 	curPath := getCurPath()
 	ctx := logger.WithCtx(context.Background(), logger.GetNop())
 	var output bytes.Buffer
-	PrintShortOtelConfig(ctx, &output)
+	err := PrintShortOtelConfig(ctx, &output)
+	assert.NoError(t, err)
 	expected, err := os.ReadFile(filepath.Join(curPath, test.outputPath))
 	assert.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(string(expected)), strings.TrimSpace(output.String()))
@@ -191,6 +192,7 @@ func getTemplateOverrides(t *testing.T, packageType PackageType) map[string]embe
 }
 
 func setEnvVars(t *testing.T, packageType PackageType) {
+	os.Setenv("TEST_ENV_VAR", "test-value")
 	switch packageType {
 	case MacOS:
 		assert.NoError(t, os.Setenv("FILESTORAGE_PATH", "/var/lib/observe-agent/filestorage"))

--- a/internal/commands/config/test/snap2-otel-config.yaml
+++ b/internal/commands/config/test/snap2-otel-config.yaml
@@ -2,6 +2,16 @@ receivers:
   filelog/test:
     include: ["./test.log"]
 
+processors:
+  attributes/test:
+    actions:
+      - action: insert
+        key: test-env-attr1
+        value: ${TEST_ENV_VAR}
+      - action: insert
+        key: test-env-attr2
+        value: ${env:TEST_ENV_VAR}
+
 service:
     pipelines:
         logs/test:
@@ -12,6 +22,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/test
                 - batch
             exporters:
                 - otlphttp/observe

--- a/internal/commands/config/test/snap2-with-otel-output.yaml
+++ b/internal/commands/config/test/snap2-with-otel-output.yaml
@@ -29,6 +29,14 @@ extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage
 processors:
+    attributes/test:
+        actions:
+            - action: insert
+              key: test-env-attr1
+              value: test-value
+            - action: insert
+              key: test-env-attr2
+              value: test-value
     batch:
         timeout: 5s
     deltatocumulative: null
@@ -108,6 +116,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - attributes/test
                 - batch
             receivers:
                 - filelog/test

--- a/observecol/otelcollector.go
+++ b/observecol/otelcollector.go
@@ -30,7 +30,7 @@ func generateCollectorSettings(URIs []string) *otelcol.CollectorSettings {
 		ConfigProviderSettings: otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
 				URIs:          URIs,
-				DefaultScheme: "file",
+				DefaultScheme: "env",
 				ProviderFactories: []confmap.ProviderFactory{
 					fileprovider.NewFactory(),
 					envprovider.NewFactory(),


### PR DESCRIPTION
### Description

Use "env" as the default config resolver schema so `${TOKEN}` in passed in config will read from an environment variable (just like `${env:TOKEN}`).