### PR TITLE
fix: remove setting of stable feature gates, add feature gate error logging

### DIFF
--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -110,7 +110,10 @@ func InitConfig() {
 	}
 
 	// Apply feature gates
-	observecol.ApplyFeatureGates(ctx)
+	err := observecol.ApplyFeatureGates(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error applying feature gates: %s\n", err.Error())
+	}
 
 	// Set up env vars
 	if err := setEnvVars(); err != nil {

--- a/observecol/feature_gates.go
+++ b/observecol/feature_gates.go
@@ -20,8 +20,6 @@ var featureGates []string
 
 var internalFeatureFlagDefaults = map[string]bool{
 	"exporter.prometheusremotewritexporter.EnableMultipleWorkers": true,
-	"receiver.prometheusreceiver.RemoveLegacyResourceAttributes":  false,
-	"receiver.kubeletstats.enableCPUUsageMetrics":                 false,
 }
 
 func AddFeatureGateFlag(flags *pflag.FlagSet) {


### PR DESCRIPTION
### Description

These two gates were upgraded to stable and now cannot be turned off. We will have to use processors to preserve backwards compatibility when necessary. We were missing any error logging, so I added that as well. 
