### PR TITLE
chore: ignore vendor files and test data in orca scans, clean up warnings

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -25,6 +25,7 @@ jobs:
           api_token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}
           project_key: ${{ env.PROJECT_KEY }}
           path: "."
+          exclude_paths: "vendor"
 
       - name: Run Orca FS Scan
         uses: orcasecurity/shiftleft-fs-action@v1
@@ -32,6 +33,7 @@ jobs:
           api_token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}
           project_key: ${{ env.PROJECT_KEY }}
           path: "."
+          exclude_paths: "vendor,components/processors/observek8sattributesprocessor/testdata"
 
   orca-container-scan:
     name: Orca Container Image Scan
@@ -52,6 +54,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.24.6
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/scripts/generate_jsonschema.go
+++ b/scripts/generate_jsonschema.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// Write to file
-	if err := os.WriteFile("observe-agent.schema.json", prettySchema, 0644); err != nil {
+	if err := os.WriteFile("observe-agent.schema.json", prettySchema, 0600); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing schema to file: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This fixes most of the ORCA warnings that we have; the rest after this have to do with our docker image generation.