### PR TITLE
fix: pin promtheus version to fix observe-agent metric output format and status check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -519,12 +519,9 @@ require (
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )
 
-// TODO remove the expr-lang/expr, x/net, and x/oauth2 replacements once our dependencies are updated beyond the vulnerable versions.
 replace (
-	github.com/Microsoft/go-winio => github.com/microsoft/go-winio v0.6.2
-	github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.0
 	github.com/observeinc/observe-agent/components/processors/observek8sattributesprocessor v0.0.0-00010101000000-000000000000 => ./components/processors/observek8sattributesprocessor
 	github.com/observeinc/observe-agent/observecol => ./observecol
-	golang.org/x/net => golang.org/x/net v0.38.0
-	golang.org/x/oauth2 => golang.org/x/oauth2 v0.27.0
+	// TODO remove this replacement once the otel upstream is fixed; see: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/1067
+	go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0
 )

--- a/vendor/github.com/expr-lang/expr/SECURITY.md
+++ b/vendor/github.com/expr-lang/expr/SECURITY.md
@@ -11,11 +11,8 @@ unless this is not possible or feasible with a reasonable effort.
 
 | Version | Supported          |
 |---------|--------------------|
-| 1.16    | :white_check_mark: |
-| 1.15    | :white_check_mark: |
-| 1.14    | :white_check_mark: |
-| 1.13    | :white_check_mark: |
-| < 1.13  | :x:                |
+| 1.x     | :white_check_mark: |
+| 0.x     | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/vendor/github.com/expr-lang/expr/builtin/lib.go
+++ b/vendor/github.com/expr-lang/expr/builtin/lib.go
@@ -374,6 +374,10 @@ func get(params ...any) (out any, err error) {
 	i := params[1]
 	v := reflect.ValueOf(from)
 
+	if from == nil {
+		return nil, nil
+	}
+
 	if v.Kind() == reflect.Invalid {
 		panic(fmt.Sprintf("cannot fetch %v from %T", i, from))
 	}

--- a/vendor/github.com/expr-lang/expr/checker/nature/utils.go
+++ b/vendor/github.com/expr-lang/expr/checker/nature/utils.go
@@ -14,6 +14,11 @@ func fieldName(field reflect.StructField) string {
 }
 
 func fetchField(t reflect.Type, name string) (reflect.StructField, bool) {
+	// If t is not a struct, early return.
+	if t.Kind() != reflect.Struct {
+		return reflect.StructField{}, false
+	}
+
 	// First check all structs fields.
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/vendor/github.com/expr-lang/expr/compiler/compiler.go
+++ b/vendor/github.com/expr-lang/expr/compiler/compiler.go
@@ -776,12 +776,16 @@ func (c *compiler) CallNode(node *ast.CallNode) {
 	}
 	c.compile(node.Callee)
 
-	isMethod, _, _ := checker.MethodIndex(c.config.Env, node.Callee)
-	if index, ok := checker.TypedFuncIndex(node.Callee.Type(), isMethod); ok {
-		c.emit(OpCallTyped, index)
-		return
-	} else if checker.IsFastFunc(node.Callee.Type(), isMethod) {
-		c.emit(OpCallFast, len(node.Arguments))
+	if c.config != nil {
+		isMethod, _, _ := checker.MethodIndex(c.config.Env, node.Callee)
+		if index, ok := checker.TypedFuncIndex(node.Callee.Type(), isMethod); ok {
+			c.emit(OpCallTyped, index)
+			return
+		} else if checker.IsFastFunc(node.Callee.Type(), isMethod) {
+			c.emit(OpCallFast, len(node.Arguments))
+		} else {
+			c.emit(OpCall, len(node.Arguments))
+		}
 	} else {
 		c.emit(OpCall, len(node.Arguments))
 	}

--- a/vendor/github.com/expr-lang/expr/conf/config.go
+++ b/vendor/github.com/expr-lang/expr/conf/config.go
@@ -10,43 +10,41 @@ import (
 	"github.com/expr-lang/expr/vm/runtime"
 )
 
-const (
-	// DefaultMemoryBudget represents an upper limit of memory usage
+var (
+	// DefaultMemoryBudget represents default maximum allowed memory usage by the vm.VM.
 	DefaultMemoryBudget uint = 1e6
 
-	// DefaultMaxNodes represents an upper limit of AST nodes
-	DefaultMaxNodes uint = 10000
+	// DefaultMaxNodes represents default maximum allowed AST nodes by the compiler.
+	DefaultMaxNodes uint = 1e4
 )
 
 type FunctionsTable map[string]*builtin.Function
 
 type Config struct {
-	EnvObject    any
-	Env          nature.Nature
-	Expect       reflect.Kind
-	ExpectAny    bool
-	Optimize     bool
-	Strict       bool
-	Profile      bool
-	MaxNodes     uint
-	MemoryBudget uint
-	ConstFns     map[string]reflect.Value
-	Visitors     []ast.Visitor
-	Functions    FunctionsTable
-	Builtins     FunctionsTable
-	Disabled     map[string]bool // disabled builtins
+	EnvObject any
+	Env       nature.Nature
+	Expect    reflect.Kind
+	ExpectAny bool
+	Optimize  bool
+	Strict    bool
+	Profile   bool
+	MaxNodes  uint
+	ConstFns  map[string]reflect.Value
+	Visitors  []ast.Visitor
+	Functions FunctionsTable
+	Builtins  FunctionsTable
+	Disabled  map[string]bool // disabled builtins
 }
 
 // CreateNew creates new config with default values.
 func CreateNew() *Config {
 	c := &Config{
-		Optimize:     true,
-		MaxNodes:     DefaultMaxNodes,
-		MemoryBudget: DefaultMemoryBudget,
-		ConstFns:     make(map[string]reflect.Value),
-		Functions:    make(map[string]*builtin.Function),
-		Builtins:     make(map[string]*builtin.Function),
-		Disabled:     make(map[string]bool),
+		Optimize:  true,
+		MaxNodes:  DefaultMaxNodes,
+		ConstFns:  make(map[string]reflect.Value),
+		Functions: make(map[string]*builtin.Function),
+		Builtins:  make(map[string]*builtin.Function),
+		Disabled:  make(map[string]bool),
 	}
 	for _, f := range builtin.Builtins {
 		c.Builtins[f.Name] = f

--- a/vendor/github.com/expr-lang/expr/vm/vm.go
+++ b/vendor/github.com/expr-lang/expr/vm/vm.go
@@ -75,7 +75,6 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 	if len(vm.Variables) < program.variables {
 		vm.Variables = make([]any, program.variables)
 	}
-
 	if vm.MemoryBudget == 0 {
 		vm.MemoryBudget = conf.DefaultMemoryBudget
 	}

--- a/vendor/go.opentelemetry.io/otel/exporters/prometheus/config.go
+++ b/vendor/go.opentelemetry.io/otel/exporters/prometheus/config.go
@@ -125,8 +125,9 @@ func WithoutCounterSuffixes() Option {
 	})
 }
 
-// WithoutScopeInfo configures the Exporter to not export
-// labels about Instrumentation Scope to all metric points.
+// WithoutScopeInfo configures the Exporter to not export the otel_scope_info metric.
+// If not specified, the Exporter will create a otel_scope_info metric containing
+// the metrics' Instrumentation Scope, and also add labels about Instrumentation Scope to all metric points.
 func WithoutScopeInfo() Option {
 	return optionFunc(func(cfg config) config {
 		cfg.disableScopeInfo = true
@@ -135,7 +136,7 @@ func WithoutScopeInfo() Option {
 }
 
 // WithNamespace configures the Exporter to prefix metric with the given namespace.
-// Metadata metrics such as target_info are not prefixed since these
+// Metadata metrics such as target_info and otel_scope_info are not prefixed since these
 // have special behavior based on their name.
 func WithNamespace(ns string) Option {
 	return optionFunc(func(cfg config) config {

--- a/vendor/go.opentelemetry.io/otel/exporters/prometheus/exporter.go
+++ b/vendor/go.opentelemetry.io/otel/exporters/prometheus/exporter.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/global"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -30,20 +31,25 @@ const (
 	targetInfoMetricName  = "target_info"
 	targetInfoDescription = "Target metadata"
 
-	scopeLabelPrefix  = "otel_scope_"
-	scopeNameLabel    = scopeLabelPrefix + "name"
-	scopeVersionLabel = scopeLabelPrefix + "version"
-	scopeSchemaLabel  = scopeLabelPrefix + "schema_url"
+	scopeInfoMetricName  = "otel_scope_info"
+	scopeInfoDescription = "Instrumentation Scope metadata"
+
+	scopeNameLabel    = "otel_scope_name"
+	scopeVersionLabel = "otel_scope_version"
 
 	traceIDExemplarKey = "trace_id"
 	spanIDExemplarKey  = "span_id"
 )
 
-var metricsPool = sync.Pool{
-	New: func() interface{} {
-		return &metricdata.ResourceMetrics{}
-	},
-}
+var (
+	errScopeInvalid = errors.New("invalid scope")
+
+	metricsPool = sync.Pool{
+		New: func() interface{} {
+			return &metricdata.ResourceMetrics{}
+		},
+	}
+)
 
 // Exporter is a Prometheus Exporter that embeds the OTel metric.Reader
 // interface for easy instantiation with a MeterProvider.
@@ -91,6 +97,8 @@ type collector struct {
 	mu                sync.Mutex // mu protects all members below from the concurrent access.
 	disableTargetInfo bool
 	targetInfo        prometheus.Metric
+	scopeInfos        map[instrumentation.Scope]prometheus.Metric
+	scopeInfosInvalid map[instrumentation.Scope]struct{}
 	metricFamilies    map[string]*dto.MetricFamily
 	resourceKeyVals   keyVals
 }
@@ -114,6 +122,8 @@ func New(opts ...Option) (*Exporter, error) {
 		withoutUnits:             cfg.withoutUnits,
 		withoutCounterSuffixes:   cfg.withoutCounterSuffixes,
 		disableScopeInfo:         cfg.disableScopeInfo,
+		scopeInfos:               make(map[instrumentation.Scope]prometheus.Metric),
+		scopeInfosInvalid:        make(map[instrumentation.Scope]struct{}),
 		metricFamilies:           make(map[string]*dto.MetricFamily),
 		namespace:                cfg.namespace,
 		resourceAttributesFilter: cfg.resourceAttributesFilter,
@@ -192,15 +202,20 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		if !c.disableScopeInfo {
-			kv.keys = append(kv.keys, scopeNameLabel, scopeVersionLabel, scopeSchemaLabel)
-			kv.vals = append(kv.vals, scopeMetrics.Scope.Name, scopeMetrics.Scope.Version, scopeMetrics.Scope.SchemaURL)
-
-			attrKeys, attrVals := getAttrs(scopeMetrics.Scope.Attributes)
-			for i := range attrKeys {
-				attrKeys[i] = scopeLabelPrefix + attrKeys[i]
+			scopeInfo, err := c.scopeInfo(scopeMetrics.Scope)
+			if errors.Is(err, errScopeInvalid) {
+				// Do not report the same error multiple times.
+				continue
 			}
-			kv.keys = append(kv.keys, attrKeys...)
-			kv.vals = append(kv.vals, attrVals...)
+			if err != nil {
+				otel.Handle(err)
+				continue
+			}
+
+			ch <- scopeInfo
+
+			kv.keys = append(kv.keys, scopeNameLabel, scopeVersionLabel)
+			kv.vals = append(kv.vals, scopeMetrics.Scope.Name, scopeMetrics.Scope.Version)
 		}
 
 		kv.keys = append(kv.keys, c.resourceKeyVals.keys...)
@@ -244,59 +259,6 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-// downscaleExponentialBucket re-aggregates bucket counts when downscaling to a coarser resolution.
-func downscaleExponentialBucket(bucket metricdata.ExponentialBucket, scaleDelta int32) metricdata.ExponentialBucket {
-	if len(bucket.Counts) == 0 || scaleDelta < 1 {
-		return metricdata.ExponentialBucket{
-			Offset: bucket.Offset >> scaleDelta,
-			Counts: append([]uint64(nil), bucket.Counts...), // copy slice
-		}
-	}
-
-	// The new offset is scaled down
-	newOffset := bucket.Offset >> scaleDelta
-
-	// Pre-calculate the new bucket count to avoid growing slice
-	// Each group of 2^scaleDelta buckets will merge into one bucket
-	//nolint:gosec // Length is bounded by slice allocation
-	lastBucketIdx := bucket.Offset + int32(len(bucket.Counts)) - 1
-	lastNewIdx := lastBucketIdx >> scaleDelta
-	newBucketCount := int(lastNewIdx - newOffset + 1)
-
-	if newBucketCount <= 0 {
-		return metricdata.ExponentialBucket{
-			Offset: newOffset,
-			Counts: []uint64{},
-		}
-	}
-
-	newCounts := make([]uint64, newBucketCount)
-
-	// Merge buckets according to the scale difference
-	for i, count := range bucket.Counts {
-		if count == 0 {
-			continue
-		}
-
-		// Calculate which new bucket this count belongs to
-		//nolint:gosec // Index is bounded by loop iteration
-		originalIdx := bucket.Offset + int32(i)
-		newIdx := originalIdx >> scaleDelta
-
-		// Calculate the position in the new counts array
-		position := newIdx - newOffset
-		//nolint:gosec // Length is bounded by allocation
-		if position >= 0 && position < int32(len(newCounts)) {
-			newCounts[position] += count
-		}
-	}
-
-	return metricdata.ExponentialBucket{
-		Offset: newOffset,
-		Counts: newCounts,
-	}
-}
-
 func addExponentialHistogramMetric[N int64 | float64](
 	ch chan<- prometheus.Metric,
 	histogram metricdata.ExponentialHistogram[N],
@@ -311,43 +273,23 @@ func addExponentialHistogramMetric[N int64 | float64](
 
 		desc := prometheus.NewDesc(name, m.Description, keys, nil)
 
-		// Prometheus native histograms support scales in the range [-4, 8]
-		scale := dp.Scale
-		if scale < -4 {
-			// Reject scales below -4 as they cannot be represented in Prometheus
-			otel.Handle(fmt.Errorf(
-				"exponential histogram scale %d is below minimum supported scale -4, skipping data point",
-				scale))
-			continue
-		}
-
-		// If scale > 8, we need to downscale the buckets to match the clamped scale
-		positiveBucket := dp.PositiveBucket
-		negativeBucket := dp.NegativeBucket
-		if scale > 8 {
-			scaleDelta := scale - 8
-			positiveBucket = downscaleExponentialBucket(dp.PositiveBucket, scaleDelta)
-			negativeBucket = downscaleExponentialBucket(dp.NegativeBucket, scaleDelta)
-			scale = 8
-		}
-
 		// From spec: note that Prometheus Native Histograms buckets are indexed by upper boundary while Exponential Histograms are indexed by lower boundary, the result being that the Offset fields are different-by-one.
 		positiveBuckets := make(map[int]int64)
-		for i, c := range positiveBucket.Counts {
+		for i, c := range dp.PositiveBucket.Counts {
 			if c > math.MaxInt64 {
 				otel.Handle(fmt.Errorf("positive count %d is too large to be represented as int64", c))
 				continue
 			}
-			positiveBuckets[int(positiveBucket.Offset)+i+1] = int64(c) // nolint: gosec  // Size check above.
+			positiveBuckets[int(dp.PositiveBucket.Offset)+i+1] = int64(c) // nolint: gosec  // Size check above.
 		}
 
 		negativeBuckets := make(map[int]int64)
-		for i, c := range negativeBucket.Counts {
+		for i, c := range dp.NegativeBucket.Counts {
 			if c > math.MaxInt64 {
 				otel.Handle(fmt.Errorf("negative count %d is too large to be represented as int64", c))
 				continue
 			}
-			negativeBuckets[int(negativeBucket.Offset)+i+1] = int64(c) // nolint: gosec  // Size check above.
+			negativeBuckets[int(dp.NegativeBucket.Offset)+i+1] = int64(c) // nolint: gosec  // Size check above.
 		}
 
 		m, err := prometheus.NewConstNativeHistogram(
@@ -357,7 +299,7 @@ func addExponentialHistogramMetric[N int64 | float64](
 			positiveBuckets,
 			negativeBuckets,
 			dp.ZeroCount,
-			scale,
+			dp.Scale,
 			dp.ZeroThreshold,
 			dp.StartTime,
 			values...)
@@ -498,11 +440,15 @@ func createInfoMetric(name, description string, res *resource.Resource) (prometh
 	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
 }
 
-func unitMapGetOrDefault(unit string) string {
-	if promUnit, ok := unitSuffixes[unit]; ok {
-		return promUnit
-	}
-	return unit
+func createScopeInfoMetric(scope instrumentation.Scope) (prometheus.Metric, error) {
+	attrs := make([]attribute.KeyValue, 0, scope.Attributes.Len()+2) // resource attrs + scope name + scope version
+	attrs = append(attrs, scope.Attributes.ToSlice()...)
+	attrs = append(attrs, attribute.String(scopeNameLabel, scope.Name))
+	attrs = append(attrs, attribute.String(scopeVersionLabel, scope.Version))
+
+	keys, values := getAttrs(attribute.NewSet(attrs...))
+	desc := prometheus.NewDesc(scopeInfoMetricName, scopeInfoDescription, keys, nil)
+	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
 }
 
 var unitSuffixes = map[string]string{
@@ -563,7 +509,7 @@ func (c *collector) getName(m metricdata.Metrics, typ *dto.MetricType) string {
 	if c.namespace != "" {
 		name = c.namespace + name
 	}
-	if suffix := unitMapGetOrDefault(m.Unit); suffix != "" && !c.withoutUnits && !strings.HasSuffix(name, suffix) {
+	if suffix, ok := unitSuffixes[m.Unit]; ok && !c.withoutUnits && !strings.HasSuffix(name, suffix) {
 		name += "_" + suffix
 	}
 	if addCounterSuffix {
@@ -608,6 +554,30 @@ func (c *collector) createResourceAttributes(res *resource.Resource) {
 	resourceAttrs, _ := res.Set().Filter(c.resourceAttributesFilter)
 	resourceKeys, resourceValues := getAttrs(resourceAttrs)
 	c.resourceKeyVals = keyVals{keys: resourceKeys, vals: resourceValues}
+}
+
+func (c *collector) scopeInfo(scope instrumentation.Scope) (prometheus.Metric, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	scopeInfo, ok := c.scopeInfos[scope]
+	if ok {
+		return scopeInfo, nil
+	}
+
+	if _, ok := c.scopeInfosInvalid[scope]; ok {
+		return nil, errScopeInvalid
+	}
+
+	scopeInfo, err := createScopeInfoMetric(scope)
+	if err != nil {
+		c.scopeInfosInvalid[scope] = struct{}{}
+		return nil, fmt.Errorf("cannot create scope info metric: %w", err)
+	}
+
+	c.scopeInfos[scope] = scopeInfo
+
+	return scopeInfo, nil
 }
 
 func (c *collector) validateMetrics(name, description string, metricType *dto.MetricType) (drop bool, help string) {

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -39,7 +39,7 @@ const (
 	FrameContinuation FrameType = 0x9
 )
 
-var frameName = map[FrameType]string{
+var frameNames = [...]string{
 	FrameData:         "DATA",
 	FrameHeaders:      "HEADERS",
 	FramePriority:     "PRIORITY",
@@ -53,10 +53,10 @@ var frameName = map[FrameType]string{
 }
 
 func (t FrameType) String() string {
-	if s, ok := frameName[t]; ok {
-		return s
+	if int(t) < len(frameNames) {
+		return frameNames[t]
 	}
-	return fmt.Sprintf("UNKNOWN_FRAME_TYPE_%d", uint8(t))
+	return fmt.Sprintf("UNKNOWN_FRAME_TYPE_%d", t)
 }
 
 // Flags is a bitmask of HTTP/2 flags.
@@ -124,7 +124,7 @@ var flagName = map[FrameType]map[Flags]string{
 // might be 0).
 type frameParser func(fc *frameCache, fh FrameHeader, countError func(string), payload []byte) (Frame, error)
 
-var frameParsers = map[FrameType]frameParser{
+var frameParsers = [...]frameParser{
 	FrameData:         parseDataFrame,
 	FrameHeaders:      parseHeadersFrame,
 	FramePriority:     parsePriorityFrame,
@@ -138,8 +138,8 @@ var frameParsers = map[FrameType]frameParser{
 }
 
 func typeFrameParser(t FrameType) frameParser {
-	if f := frameParsers[t]; f != nil {
-		return f
+	if int(t) < len(frameParsers) {
+		return frameParsers[t]
 	}
 	return parseUnknownFrame
 }
@@ -509,7 +509,7 @@ func (fr *Framer) ReadFrame() (Frame, error) {
 	}
 	if fh.Length > fr.maxReadSize {
 		if fh == invalidHTTP1LookingFrameHeader() {
-			return nil, fmt.Errorf("http2: failed reading the frame payload: %w, note that the frame header looked like an HTTP/1.1 header", err)
+			return nil, fmt.Errorf("http2: failed reading the frame payload: %w, note that the frame header looked like an HTTP/1.1 header", ErrFrameTooLarge)
 		}
 		return nil, ErrFrameTooLarge
 	}

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -508,7 +508,7 @@ const eventsHTML = `
 	<tr class="first">
 		<td class="when">{{$el.When}}</td>
 		<td class="elapsed">{{$el.ElapsedTime}}</td>
-		<td>{{$el.Title}}
+		<td>{{$el.Title}}</td>
 	</tr>
 	{{if $.Expanded}}
 	<tr>

--- a/vendor/golang.org/x/oauth2/authhandler/authhandler.go
+++ b/vendor/golang.org/x/oauth2/authhandler/authhandler.go
@@ -34,7 +34,7 @@ type PKCEParams struct {
 // and returns an auth code and state upon approval.
 type AuthorizationHandler func(authCodeURL string) (code string, state string, err error)
 
-// TokenSourceWithPKCE is an enhanced version of TokenSource with PKCE support.
+// TokenSourceWithPKCE is an enhanced version of [oauth2.TokenSource] with PKCE support.
 //
 // The pkce parameter supports PKCE flow, which uses code challenge and code verifier
 // to prevent CSRF attacks. A unique code challenge and code verifier should be generated
@@ -43,12 +43,12 @@ func TokenSourceWithPKCE(ctx context.Context, config *oauth2.Config, state strin
 	return oauth2.ReuseTokenSource(nil, authHandlerSource{config: config, ctx: ctx, authHandler: authHandler, state: state, pkce: pkce})
 }
 
-// TokenSource returns an oauth2.TokenSource that fetches access tokens
+// TokenSource returns an [oauth2.TokenSource] that fetches access tokens
 // using 3-legged-OAuth flow.
 //
-// The provided context.Context is used for oauth2 Exchange operation.
+// The provided [context.Context] is used for oauth2 Exchange operation.
 //
-// The provided oauth2.Config should be a full configuration containing AuthURL,
+// The provided [oauth2.Config] should be a full configuration containing AuthURL,
 // TokenURL, and Scope.
 //
 // An environment-specific AuthorizationHandler is used to obtain user consent.

--- a/vendor/golang.org/x/oauth2/clientcredentials/clientcredentials.go
+++ b/vendor/golang.org/x/oauth2/clientcredentials/clientcredentials.go
@@ -55,7 +55,7 @@ type Config struct {
 
 // Token uses client credentials to retrieve a token.
 //
-// The provided context optionally controls which HTTP client is used. See the oauth2.HTTPClient variable.
+// The provided context optionally controls which HTTP client is used. See the [oauth2.HTTPClient] variable.
 func (c *Config) Token(ctx context.Context) (*oauth2.Token, error) {
 	return c.TokenSource(ctx).Token()
 }
@@ -64,18 +64,18 @@ func (c *Config) Token(ctx context.Context) (*oauth2.Token, error) {
 // The token will auto-refresh as necessary.
 //
 // The provided context optionally controls which HTTP client
-// is returned. See the oauth2.HTTPClient variable.
+// is returned. See the [oauth2.HTTPClient] variable.
 //
-// The returned Client and its Transport should not be modified.
+// The returned [http.Client] and its Transport should not be modified.
 func (c *Config) Client(ctx context.Context) *http.Client {
 	return oauth2.NewClient(ctx, c.TokenSource(ctx))
 }
 
-// TokenSource returns a TokenSource that returns t until t expires,
+// TokenSource returns a [oauth2.TokenSource] that returns t until t expires,
 // automatically refreshing it as necessary using the provided context and the
 // client ID and client secret.
 //
-// Most users will use Config.Client instead.
+// Most users will use [Config.Client] instead.
 func (c *Config) TokenSource(ctx context.Context) oauth2.TokenSource {
 	source := &tokenSource{
 		ctx:  ctx,

--- a/vendor/golang.org/x/oauth2/google/externalaccount/aws.go
+++ b/vendor/golang.org/x/oauth2/google/externalaccount/aws.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -170,7 +169,7 @@ func requestDataHash(req *http.Request) (string, error) {
 		}
 		defer requestBody.Close()
 
-		requestData, err = ioutil.ReadAll(io.LimitReader(requestBody, 1<<20))
+		requestData, err = io.ReadAll(io.LimitReader(requestBody, 1<<20))
 		if err != nil {
 			return "", err
 		}
@@ -419,7 +418,7 @@ func (cs *awsCredentialSource) getAWSSessionToken() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", err
 	}
@@ -462,7 +461,7 @@ func (cs *awsCredentialSource) getRegion(headers map[string]string) (string, err
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", err
 	}
@@ -531,7 +530,7 @@ func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string, h
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return result, err
 	}
@@ -564,7 +563,7 @@ func (cs *awsCredentialSource) getMetadataRoleName(headers map[string]string) (s
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", err
 	}

--- a/vendor/golang.org/x/oauth2/google/externalaccount/basecredentials.go
+++ b/vendor/golang.org/x/oauth2/google/externalaccount/basecredentials.go
@@ -263,7 +263,7 @@ const (
 	fileTypeJSON = "json"
 )
 
-// Format contains information needed to retireve a subject token for URL or File sourced credentials.
+// Format contains information needed to retrieve a subject token for URL or File sourced credentials.
 type Format struct {
 	// Type should be either "text" or "json". This determines whether the file or URL sourced credentials
 	// expect a simple text subject token or if the subject token will be contained in a JSON object.
@@ -486,11 +486,11 @@ func (ts tokenSource) Token() (*oauth2.Token, error) {
 		ClientID:     conf.ClientID,
 		ClientSecret: conf.ClientSecret,
 	}
-	var options map[string]interface{}
+	var options map[string]any
 	// Do not pass workforce_pool_user_project when client authentication is used.
 	// The client ID is sufficient for determining the user project.
 	if conf.WorkforcePoolUserProject != "" && conf.ClientID == "" {
-		options = map[string]interface{}{
+		options = map[string]any{
 			"userProject": conf.WorkforcePoolUserProject,
 		}
 	}

--- a/vendor/golang.org/x/oauth2/google/externalaccount/executablecredsource.go
+++ b/vendor/golang.org/x/oauth2/google/externalaccount/executablecredsource.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -258,7 +257,7 @@ func (cs executableCredentialSource) getTokenFromOutputFile() (token string, err
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(io.LimitReader(file, 1<<20))
+	data, err := io.ReadAll(io.LimitReader(file, 1<<20))
 	if err != nil || len(data) == 0 {
 		// Cachefile exists, but no data found. Get new credential.
 		return "", nil

--- a/vendor/golang.org/x/oauth2/google/externalaccount/filecredsource.go
+++ b/vendor/golang.org/x/oauth2/google/externalaccount/filecredsource.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -29,14 +28,14 @@ func (cs fileCredentialSource) subjectToken() (string, error) {
 		return "", fmt.Errorf("oauth2/google/externalaccount: failed to open credential file %q", cs.File)
 	}
 	defer tokenFile.Close()
-	tokenBytes, err := ioutil.ReadAll(io.LimitReader(tokenFile, 1<<20))
+	tokenBytes, err := io.ReadAll(io.LimitReader(tokenFile, 1<<20))
 	if err != nil {
 		return "", fmt.Errorf("oauth2/google/externalaccount: failed to read credential file: %v", err)
 	}
 	tokenBytes = bytes.TrimSpace(tokenBytes)
 	switch cs.Format.Type {
 	case "json":
-		jsonData := make(map[string]interface{})
+		jsonData := make(map[string]any)
 		err = json.Unmarshal(tokenBytes, &jsonData)
 		if err != nil {
 			return "", fmt.Errorf("oauth2/google/externalaccount: failed to unmarshal subject token file: %v", err)

--- a/vendor/golang.org/x/oauth2/google/externalaccount/urlcredsource.go
+++ b/vendor/golang.org/x/oauth2/google/externalaccount/urlcredsource.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -44,7 +43,7 @@ func (cs urlCredentialSource) subjectToken() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", fmt.Errorf("oauth2/google/externalaccount: invalid body in subject token URL query: %v", err)
 	}
@@ -54,7 +53,7 @@ func (cs urlCredentialSource) subjectToken() (string, error) {
 
 	switch cs.Format.Type {
 	case "json":
-		jsonData := make(map[string]interface{})
+		jsonData := make(map[string]any)
 		err = json.Unmarshal(respBody, &jsonData)
 		if err != nil {
 			return "", fmt.Errorf("oauth2/google/externalaccount: failed to unmarshal subject token file: %v", err)

--- a/vendor/golang.org/x/oauth2/google/google.go
+++ b/vendor/golang.org/x/oauth2/google/google.go
@@ -285,27 +285,23 @@ func (cs computeSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	var res struct {
-		AccessToken  string `json:"access_token"`
-		ExpiresInSec int    `json:"expires_in"`
-		TokenType    string `json:"token_type"`
-	}
+	var res oauth2.Token
 	err = json.NewDecoder(strings.NewReader(tokenJSON)).Decode(&res)
 	if err != nil {
 		return nil, fmt.Errorf("oauth2/google: invalid token JSON from metadata: %v", err)
 	}
-	if res.ExpiresInSec == 0 || res.AccessToken == "" {
+	if res.ExpiresIn == 0 || res.AccessToken == "" {
 		return nil, fmt.Errorf("oauth2/google: incomplete token received from metadata")
 	}
 	tok := &oauth2.Token{
 		AccessToken: res.AccessToken,
 		TokenType:   res.TokenType,
-		Expiry:      time.Now().Add(time.Duration(res.ExpiresInSec) * time.Second),
+		Expiry:      time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
 	}
 	// NOTE(cbro): add hidden metadata about where the token is from.
 	// This is needed for detection by client libraries to know that credentials come from the metadata server.
 	// This may be removed in a future version of this library.
-	return tok.WithExtra(map[string]interface{}{
+	return tok.WithExtra(map[string]any{
 		"oauth2.google.tokenSource":    "compute-metadata",
 		"oauth2.google.serviceAccount": acct,
 	}), nil

--- a/vendor/golang.org/x/oauth2/google/internal/impersonate/impersonate.go
+++ b/vendor/golang.org/x/oauth2/google/internal/impersonate/impersonate.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -81,7 +80,7 @@ func (its ImpersonateTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("oauth2/google: unable to generate access token: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2/google: unable to read body: %v", err)
 	}

--- a/vendor/golang.org/x/oauth2/google/internal/stsexchange/sts_exchange.go
+++ b/vendor/golang.org/x/oauth2/google/internal/stsexchange/sts_exchange.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,7 +27,7 @@ func defaultHeader() http.Header {
 // The first 4 fields are all mandatory.  headers can be used to pass additional
 // headers beyond the bare minimum required by the token exchange.  options can
 // be used to pass additional JSON-structured options to the remote server.
-func ExchangeToken(ctx context.Context, endpoint string, request *TokenExchangeRequest, authentication ClientAuthentication, headers http.Header, options map[string]interface{}) (*Response, error) {
+func ExchangeToken(ctx context.Context, endpoint string, request *TokenExchangeRequest, authentication ClientAuthentication, headers http.Header, options map[string]any) (*Response, error) {
 	data := url.Values{}
 	data.Set("audience", request.Audience)
 	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
@@ -82,7 +81,7 @@ func makeRequest(ctx context.Context, endpoint string, data url.Values, authenti
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/golang.org/x/oauth2/internal/doc.go
+++ b/vendor/golang.org/x/oauth2/internal/doc.go
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package internal contains support packages for oauth2 package.
+// Package internal contains support packages for [golang.org/x/oauth2].
 package internal

--- a/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ParseKey converts the binary contents of a private key file
-// to an *rsa.PrivateKey. It detects whether the private key is in a
+// to an [*rsa.PrivateKey]. It detects whether the private key is in a
 // PEM container or not. If so, it extracts the private key
 // from PEM container before conversion. It only supports PEM
 // containers with no passphrase.

--- a/vendor/golang.org/x/oauth2/internal/token.go
+++ b/vendor/golang.org/x/oauth2/internal/token.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"mime"
 	"net/http"
@@ -26,9 +25,9 @@ import (
 // the requests to access protected resources on the OAuth 2.0
 // provider's backend.
 //
-// This type is a mirror of oauth2.Token and exists to break
+// This type is a mirror of [golang.org/x/oauth2.Token] and exists to break
 // an otherwise-circular dependency. Other internal packages
-// should convert this Token into an oauth2.Token before use.
+// should convert this Token into an [golang.org/x/oauth2.Token] before use.
 type Token struct {
 	// AccessToken is the token that authorizes and authenticates
 	// the requests.
@@ -50,9 +49,16 @@ type Token struct {
 	// mechanisms for that TokenSource will not be used.
 	Expiry time.Time
 
+	// ExpiresIn is the OAuth2 wire format "expires_in" field,
+	// which specifies how many seconds later the token expires,
+	// relative to an unknown time base approximately around "now".
+	// It is the application's responsibility to populate
+	// `Expiry` from `ExpiresIn` when required.
+	ExpiresIn int64 `json:"expires_in,omitempty"`
+
 	// Raw optionally contains extra metadata from the server
 	// when updating a token.
-	Raw interface{}
+	Raw any
 }
 
 // tokenJSON is the struct representing the HTTP response from OAuth2
@@ -99,14 +105,6 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// RegisterBrokenAuthHeaderProvider previously did something. It is now a no-op.
-//
-// Deprecated: this function no longer does anything. Caller code that
-// wants to avoid potential extra HTTP requests made during
-// auto-probing of the provider's auth style should set
-// Endpoint.AuthStyle.
-func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
-
 // AuthStyle is a copy of the golang.org/x/oauth2 package's AuthStyle type.
 type AuthStyle int
 
@@ -143,6 +141,11 @@ func (lc *LazyAuthStyleCache) Get() *AuthStyleCache {
 	return c
 }
 
+type authStyleCacheKey struct {
+	url      string
+	clientID string
+}
+
 // AuthStyleCache is the set of tokenURLs we've successfully used via
 // RetrieveToken and which style auth we ended up using.
 // It's called a cache, but it doesn't (yet?) shrink. It's expected that
@@ -150,26 +153,26 @@ func (lc *LazyAuthStyleCache) Get() *AuthStyleCache {
 // small.
 type AuthStyleCache struct {
 	mu sync.Mutex
-	m  map[string]AuthStyle // keyed by tokenURL
+	m  map[authStyleCacheKey]AuthStyle
 }
 
 // lookupAuthStyle reports which auth style we last used with tokenURL
 // when calling RetrieveToken and whether we have ever done so.
-func (c *AuthStyleCache) lookupAuthStyle(tokenURL string) (style AuthStyle, ok bool) {
+func (c *AuthStyleCache) lookupAuthStyle(tokenURL, clientID string) (style AuthStyle, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	style, ok = c.m[tokenURL]
+	style, ok = c.m[authStyleCacheKey{tokenURL, clientID}]
 	return
 }
 
 // setAuthStyle adds an entry to authStyleCache, documented above.
-func (c *AuthStyleCache) setAuthStyle(tokenURL string, v AuthStyle) {
+func (c *AuthStyleCache) setAuthStyle(tokenURL, clientID string, v AuthStyle) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.m == nil {
-		c.m = make(map[string]AuthStyle)
+		c.m = make(map[authStyleCacheKey]AuthStyle)
 	}
-	c.m[tokenURL] = v
+	c.m[authStyleCacheKey{tokenURL, clientID}] = v
 }
 
 // newTokenRequest returns a new *http.Request to retrieve a new token
@@ -210,9 +213,9 @@ func cloneURLValues(v url.Values) url.Values {
 }
 
 func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values, authStyle AuthStyle, styleCache *AuthStyleCache) (*Token, error) {
-	needsAuthStyleProbe := authStyle == 0
+	needsAuthStyleProbe := authStyle == AuthStyleUnknown
 	if needsAuthStyleProbe {
-		if style, ok := styleCache.lookupAuthStyle(tokenURL); ok {
+		if style, ok := styleCache.lookupAuthStyle(tokenURL, clientID); ok {
 			authStyle = style
 			needsAuthStyleProbe = false
 		} else {
@@ -242,7 +245,7 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 		token, err = doTokenRoundTrip(ctx, req)
 	}
 	if needsAuthStyleProbe && err == nil {
-		styleCache.setAuthStyle(tokenURL, authStyle)
+		styleCache.setAuthStyle(tokenURL, clientID, authStyle)
 	}
 	// Don't overwrite `RefreshToken` with an empty value
 	// if this was a token refreshing request.
@@ -257,7 +260,7 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	r.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
@@ -312,7 +315,8 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 			TokenType:    tj.TokenType,
 			RefreshToken: tj.RefreshToken,
 			Expiry:       tj.expiry(),
-			Raw:          make(map[string]interface{}),
+			ExpiresIn:    int64(tj.ExpiresIn),
+			Raw:          make(map[string]any),
 		}
 		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
 	}

--- a/vendor/golang.org/x/oauth2/internal/transport.go
+++ b/vendor/golang.org/x/oauth2/internal/transport.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 )
 
-// HTTPClient is the context key to use with golang.org/x/net/context's
-// WithValue function to associate an *http.Client value with a context.
+// HTTPClient is the context key to use with [context.WithValue]
+// to associate an [*http.Client] value with a context.
 var HTTPClient ContextKey
 
 // ContextKey is just an empty struct. It exists so HTTPClient can be

--- a/vendor/golang.org/x/oauth2/jws/jws.go
+++ b/vendor/golang.org/x/oauth2/jws/jws.go
@@ -4,7 +4,7 @@
 
 // Package jws provides a partial implementation
 // of JSON Web Signature encoding and decoding.
-// It exists to support the golang.org/x/oauth2 package.
+// It exists to support the [golang.org/x/oauth2] package.
 //
 // See RFC 7515.
 //
@@ -48,7 +48,7 @@ type ClaimSet struct {
 
 	// See http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.3
 	// This array is marshalled using custom code (see (c *ClaimSet) encode()).
-	PrivateClaims map[string]interface{} `json:"-"`
+	PrivateClaims map[string]any `json:"-"`
 }
 
 func (c *ClaimSet) encode() (string, error) {
@@ -116,12 +116,12 @@ func (h *Header) encode() (string, error) {
 // Decode decodes a claim set from a JWS payload.
 func Decode(payload string) (*ClaimSet, error) {
 	// decode returned id token to get expiry
-	s := strings.Split(payload, ".")
-	if len(s) < 2 {
+	_, claims, _, ok := parseToken(payload)
+	if !ok {
 		// TODO(jbd): Provide more context about the error.
 		return nil, errors.New("jws: invalid token received")
 	}
-	decoded, err := base64.RawURLEncoding.DecodeString(s[1])
+	decoded, err := base64.RawURLEncoding.DecodeString(claims)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func EncodeWithSigner(header *Header, c *ClaimSet, sg Signer) (string, error) {
 }
 
 // Encode encodes a signed JWS with provided header and claim set.
-// This invokes EncodeWithSigner using crypto/rsa.SignPKCS1v15 with the given RSA private key.
+// This invokes [EncodeWithSigner] using [crypto/rsa.SignPKCS1v15] with the given RSA private key.
 func Encode(header *Header, c *ClaimSet, key *rsa.PrivateKey) (string, error) {
 	sg := func(data []byte) (sig []byte, err error) {
 		h := sha256.New()
@@ -165,18 +165,34 @@ func Encode(header *Header, c *ClaimSet, key *rsa.PrivateKey) (string, error) {
 // Verify tests whether the provided JWT token's signature was produced by the private key
 // associated with the supplied public key.
 func Verify(token string, key *rsa.PublicKey) error {
-	if strings.Count(token, ".") != 2 {
+	header, claims, sig, ok := parseToken(token)
+	if !ok {
 		return errors.New("jws: invalid token received, token must have 3 parts")
 	}
-
-	parts := strings.SplitN(token, ".", 3)
-	signedContent := parts[0] + "." + parts[1]
-	signatureString, err := base64.RawURLEncoding.DecodeString(parts[2])
+	signatureString, err := base64.RawURLEncoding.DecodeString(sig)
 	if err != nil {
 		return err
 	}
 
 	h := sha256.New()
-	h.Write([]byte(signedContent))
+	h.Write([]byte(header + tokenDelim + claims))
 	return rsa.VerifyPKCS1v15(key, crypto.SHA256, h.Sum(nil), signatureString)
 }
+
+func parseToken(s string) (header, claims, sig string, ok bool) {
+	header, s, ok = strings.Cut(s, tokenDelim)
+	if !ok { // no period found
+		return "", "", "", false
+	}
+	claims, s, ok = strings.Cut(s, tokenDelim)
+	if !ok { // only one period found
+		return "", "", "", false
+	}
+	sig, _, ok = strings.Cut(s, tokenDelim)
+	if ok { // three periods found
+		return "", "", "", false
+	}
+	return header, claims, sig, true
+}
+
+const tokenDelim = "."

--- a/vendor/golang.org/x/oauth2/jwt/jwt.go
+++ b/vendor/golang.org/x/oauth2/jwt/jwt.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +68,7 @@ type Config struct {
 
 	// PrivateClaims optionally specifies custom private claims in the JWT.
 	// See http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.3
-	PrivateClaims map[string]interface{}
+	PrivateClaims map[string]any
 
 	// UseIDToken optionally specifies whether ID token should be used instead
 	// of access token when the server returns both.
@@ -136,7 +135,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
@@ -148,10 +147,8 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	}
 	// tokenRes is the JSON response body.
 	var tokenRes struct {
-		AccessToken string `json:"access_token"`
-		TokenType   string `json:"token_type"`
-		IDToken     string `json:"id_token"`
-		ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
+		oauth2.Token
+		IDToken string `json:"id_token"`
 	}
 	if err := json.Unmarshal(body, &tokenRes); err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
@@ -160,7 +157,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		AccessToken: tokenRes.AccessToken,
 		TokenType:   tokenRes.TokenType,
 	}
-	raw := make(map[string]interface{})
+	raw := make(map[string]any)
 	json.Unmarshal(body, &raw) // no error checks for optional fields
 	token = token.WithExtra(raw)
 

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -22,9 +22,9 @@ import (
 )
 
 // NoContext is the default context you should supply if not using
-// your own context.Context (see https://golang.org/x/net/context).
+// your own [context.Context].
 //
-// Deprecated: Use context.Background() or context.TODO() instead.
+// Deprecated: Use [context.Background] or [context.TODO] instead.
 var NoContext = context.TODO()
 
 // RegisterBrokenAuthHeaderProvider previously did something. It is now a no-op.
@@ -37,8 +37,8 @@ func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
 
 // Config describes a typical 3-legged OAuth2 flow, with both the
 // client application information and the server's endpoint URLs.
-// For the client credentials 2-legged OAuth2 flow, see the clientcredentials
-// package (https://golang.org/x/oauth2/clientcredentials).
+// For the client credentials 2-legged OAuth2 flow, see the
+// [golang.org/x/oauth2/clientcredentials] package.
 type Config struct {
 	// ClientID is the application's ID.
 	ClientID string
@@ -46,7 +46,7 @@ type Config struct {
 	// ClientSecret is the application's secret.
 	ClientSecret string
 
-	// Endpoint contains the resource server's token endpoint
+	// Endpoint contains the authorization server's token endpoint
 	// URLs. These are constants specific to each server and are
 	// often available via site-specific packages, such as
 	// google.Endpoint or github.Endpoint.
@@ -135,7 +135,7 @@ type setParam struct{ k, v string }
 
 func (p setParam) setValue(m url.Values) { m.Set(p.k, p.v) }
 
-// SetAuthURLParam builds an AuthCodeOption which passes key/value parameters
+// SetAuthURLParam builds an [AuthCodeOption] which passes key/value parameters
 // to a provider's authorization endpoint.
 func SetAuthURLParam(key, value string) AuthCodeOption {
 	return setParam{key, value}
@@ -148,8 +148,8 @@ func SetAuthURLParam(key, value string) AuthCodeOption {
 // request and callback. The authorization server includes this value when
 // redirecting the user agent back to the client.
 //
-// Opts may include AccessTypeOnline or AccessTypeOffline, as well
-// as ApprovalForce.
+// Opts may include [AccessTypeOnline] or [AccessTypeOffline], as well
+// as [ApprovalForce].
 //
 // To protect against CSRF attacks, opts should include a PKCE challenge
 // (S256ChallengeOption). Not all servers support PKCE. An alternative is to
@@ -194,7 +194,7 @@ func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
 // and when other authorization grant types are not available."
 // See https://tools.ietf.org/html/rfc6749#section-4.3 for more info.
 //
-// The provided context optionally controls which HTTP client is used. See the HTTPClient variable.
+// The provided context optionally controls which HTTP client is used. See the [HTTPClient] variable.
 func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*Token, error) {
 	v := url.Values{
 		"grant_type": {"password"},
@@ -212,10 +212,10 @@ func (c *Config) PasswordCredentialsToken(ctx context.Context, username, passwor
 // It is used after a resource provider redirects the user back
 // to the Redirect URI (the URL obtained from AuthCodeURL).
 //
-// The provided context optionally controls which HTTP client is used. See the HTTPClient variable.
+// The provided context optionally controls which HTTP client is used. See the [HTTPClient] variable.
 //
-// The code will be in the *http.Request.FormValue("code"). Before
-// calling Exchange, be sure to validate FormValue("state") if you are
+// The code will be in the [http.Request.FormValue]("code"). Before
+// calling Exchange, be sure to validate [http.Request.FormValue]("state") if you are
 // using it to protect against CSRF attacks.
 //
 // If using PKCE to protect against CSRF attacks, opts should include a
@@ -242,10 +242,10 @@ func (c *Config) Client(ctx context.Context, t *Token) *http.Client {
 	return NewClient(ctx, c.TokenSource(ctx, t))
 }
 
-// TokenSource returns a TokenSource that returns t until t expires,
+// TokenSource returns a [TokenSource] that returns t until t expires,
 // automatically refreshing it as necessary using the provided context.
 //
-// Most users will use Config.Client instead.
+// Most users will use [Config.Client] instead.
 func (c *Config) TokenSource(ctx context.Context, t *Token) TokenSource {
 	tkr := &tokenRefresher{
 		ctx:  ctx,
@@ -260,7 +260,7 @@ func (c *Config) TokenSource(ctx context.Context, t *Token) TokenSource {
 	}
 }
 
-// tokenRefresher is a TokenSource that makes "grant_type"=="refresh_token"
+// tokenRefresher is a TokenSource that makes "grant_type=refresh_token"
 // HTTP requests to renew a token using a RefreshToken.
 type tokenRefresher struct {
 	ctx          context.Context // used to get HTTP requests
@@ -288,7 +288,7 @@ func (tf *tokenRefresher) Token() (*Token, error) {
 	if tf.refreshToken != tk.RefreshToken {
 		tf.refreshToken = tk.RefreshToken
 	}
-	return tk, err
+	return tk, nil
 }
 
 // reuseTokenSource is a TokenSource that holds a single token in memory
@@ -305,8 +305,7 @@ type reuseTokenSource struct {
 }
 
 // Token returns the current token if it's still valid, else will
-// refresh the current token (using r.Context for HTTP client
-// information) and return the new one.
+// refresh the current token and return the new one.
 func (s *reuseTokenSource) Token() (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -322,7 +321,7 @@ func (s *reuseTokenSource) Token() (*Token, error) {
 	return t, nil
 }
 
-// StaticTokenSource returns a TokenSource that always returns the same token.
+// StaticTokenSource returns a [TokenSource] that always returns the same token.
 // Because the provided token t is never refreshed, StaticTokenSource is only
 // useful for tokens that never expire.
 func StaticTokenSource(t *Token) TokenSource {
@@ -338,16 +337,16 @@ func (s staticTokenSource) Token() (*Token, error) {
 	return s.t, nil
 }
 
-// HTTPClient is the context key to use with golang.org/x/net/context's
-// WithValue function to associate an *http.Client value with a context.
+// HTTPClient is the context key to use with [context.WithValue]
+// to associate a [*http.Client] value with a context.
 var HTTPClient internal.ContextKey
 
-// NewClient creates an *http.Client from a Context and TokenSource.
+// NewClient creates an [*http.Client] from a [context.Context] and [TokenSource].
 // The returned client is not valid beyond the lifetime of the context.
 //
-// Note that if a custom *http.Client is provided via the Context it
+// Note that if a custom [*http.Client] is provided via the [context.Context] it
 // is used only for token acquisition and is not used to configure the
-// *http.Client returned from NewClient.
+// [*http.Client] returned from NewClient.
 //
 // As a special case, if src is nil, a non-OAuth2 client is returned
 // using the provided context. This exists to support related OAuth2
@@ -356,15 +355,19 @@ func NewClient(ctx context.Context, src TokenSource) *http.Client {
 	if src == nil {
 		return internal.ContextClient(ctx)
 	}
+	cc := internal.ContextClient(ctx)
 	return &http.Client{
 		Transport: &Transport{
-			Base:   internal.ContextClient(ctx).Transport,
+			Base:   cc.Transport,
 			Source: ReuseTokenSource(nil, src),
 		},
+		CheckRedirect: cc.CheckRedirect,
+		Jar:           cc.Jar,
+		Timeout:       cc.Timeout,
 	}
 }
 
-// ReuseTokenSource returns a TokenSource which repeatedly returns the
+// ReuseTokenSource returns a [TokenSource] which repeatedly returns the
 // same token as long as it's valid, starting with t.
 // When its cached token is invalid, a new token is obtained from src.
 //
@@ -372,10 +375,10 @@ func NewClient(ctx context.Context, src TokenSource) *http.Client {
 // (such as a file on disk) between runs of a program, rather than
 // obtaining new tokens unnecessarily.
 //
-// The initial token t may be nil, in which case the TokenSource is
+// The initial token t may be nil, in which case the [TokenSource] is
 // wrapped in a caching version if it isn't one already. This also
 // means it's always safe to wrap ReuseTokenSource around any other
-// TokenSource without adverse effects.
+// [TokenSource] without adverse effects.
 func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
 	// Don't wrap a reuseTokenSource in itself. That would work,
 	// but cause an unnecessary number of mutex operations.
@@ -393,8 +396,8 @@ func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
 	}
 }
 
-// ReuseTokenSourceWithExpiry returns a TokenSource that acts in the same manner as the
-// TokenSource returned by ReuseTokenSource, except the expiry buffer is
+// ReuseTokenSourceWithExpiry returns a [TokenSource] that acts in the same manner as the
+// [TokenSource] returned by [ReuseTokenSource], except the expiry buffer is
 // configurable. The expiration time of a token is calculated as
 // t.Expiry.Add(-earlyExpiry).
 func ReuseTokenSourceWithExpiry(t *Token, src TokenSource, earlyExpiry time.Duration) TokenSource {

--- a/vendor/golang.org/x/oauth2/pkce.go
+++ b/vendor/golang.org/x/oauth2/pkce.go
@@ -1,6 +1,7 @@
 // Copyright 2023 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package oauth2
 
 import (
@@ -20,9 +21,9 @@ const (
 // This follows recommendations in RFC 7636.
 //
 // A fresh verifier should be generated for each authorization.
-// S256ChallengeOption(verifier) should then be passed to Config.AuthCodeURL
-// (or Config.DeviceAuth) and VerifierOption(verifier) to Config.Exchange
-// (or Config.DeviceAccessToken).
+// The resulting verifier should be passed to [Config.AuthCodeURL] or [Config.DeviceAuth]
+// with [S256ChallengeOption], and to [Config.Exchange] or [Config.DeviceAccessToken]
+// with [VerifierOption].
 func GenerateVerifier() string {
 	// "RECOMMENDED that the output of a suitable random number generator be
 	// used to create a 32-octet sequence.  The octet sequence is then
@@ -36,22 +37,22 @@ func GenerateVerifier() string {
 	return base64.RawURLEncoding.EncodeToString(data)
 }
 
-// VerifierOption returns a PKCE code verifier AuthCodeOption. It should be
-// passed to Config.Exchange or Config.DeviceAccessToken only.
+// VerifierOption returns a PKCE code verifier [AuthCodeOption]. It should only be
+// passed to [Config.Exchange] or [Config.DeviceAccessToken].
 func VerifierOption(verifier string) AuthCodeOption {
 	return setParam{k: codeVerifierKey, v: verifier}
 }
 
 // S256ChallengeFromVerifier returns a PKCE code challenge derived from verifier with method S256.
 //
-// Prefer to use S256ChallengeOption where possible.
+// Prefer to use [S256ChallengeOption] where possible.
 func S256ChallengeFromVerifier(verifier string) string {
 	sha := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(sha[:])
 }
 
 // S256ChallengeOption derives a PKCE code challenge derived from verifier with
-// method S256. It should be passed to Config.AuthCodeURL or Config.DeviceAuth
+// method S256. It should be passed to [Config.AuthCodeURL] or [Config.DeviceAuth]
 // only.
 func S256ChallengeOption(verifier string) AuthCodeOption {
 	return challengeOption{

--- a/vendor/golang.org/x/oauth2/token.go
+++ b/vendor/golang.org/x/oauth2/token.go
@@ -44,7 +44,7 @@ type Token struct {
 
 	// Expiry is the optional expiration time of the access token.
 	//
-	// If zero, TokenSource implementations will reuse the same
+	// If zero, [TokenSource] implementations will reuse the same
 	// token forever and RefreshToken or equivalent
 	// mechanisms for that TokenSource will not be used.
 	Expiry time.Time `json:"expiry,omitempty"`
@@ -58,7 +58,7 @@ type Token struct {
 
 	// raw optionally contains extra metadata from the server
 	// when updating a token.
-	raw interface{}
+	raw any
 
 	// expiryDelta is used to calculate when a token is considered
 	// expired, by subtracting from Expiry. If zero, defaultExpiryDelta
@@ -86,16 +86,16 @@ func (t *Token) Type() string {
 // SetAuthHeader sets the Authorization header to r using the access
 // token in t.
 //
-// This method is unnecessary when using Transport or an HTTP Client
+// This method is unnecessary when using [Transport] or an HTTP Client
 // returned by this package.
 func (t *Token) SetAuthHeader(r *http.Request) {
 	r.Header.Set("Authorization", t.Type()+" "+t.AccessToken)
 }
 
-// WithExtra returns a new Token that's a clone of t, but using the
+// WithExtra returns a new [Token] that's a clone of t, but using the
 // provided raw extra map. This is only intended for use by packages
 // implementing derivative OAuth2 flows.
-func (t *Token) WithExtra(extra interface{}) *Token {
+func (t *Token) WithExtra(extra any) *Token {
 	t2 := new(Token)
 	*t2 = *t
 	t2.raw = extra
@@ -105,8 +105,8 @@ func (t *Token) WithExtra(extra interface{}) *Token {
 // Extra returns an extra field.
 // Extra fields are key-value pairs returned by the server as a
 // part of the token retrieval response.
-func (t *Token) Extra(key string) interface{} {
-	if raw, ok := t.raw.(map[string]interface{}); ok {
+func (t *Token) Extra(key string) any {
+	if raw, ok := t.raw.(map[string]any); ok {
 		return raw[key]
 	}
 
@@ -163,13 +163,14 @@ func tokenFromInternal(t *internal.Token) *Token {
 		TokenType:    t.TokenType,
 		RefreshToken: t.RefreshToken,
 		Expiry:       t.Expiry,
+		ExpiresIn:    t.ExpiresIn,
 		raw:          t.Raw,
 	}
 }
 
 // retrieveToken takes a *Config and uses that to retrieve an *internal.Token.
 // This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
-// with an error..
+// with an error.
 func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
 	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v, internal.AuthStyle(c.Endpoint.AuthStyle), c.authStyleCache.Get())
 	if err != nil {

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 )
 
-// Transport is an http.RoundTripper that makes OAuth 2.0 HTTP requests,
-// wrapping a base RoundTripper and adding an Authorization header
-// with a token from the supplied Sources.
+// Transport is an [http.RoundTripper] that makes OAuth 2.0 HTTP requests,
+// wrapping a base [http.RoundTripper] and adding an Authorization header
+// with a token from the supplied [TokenSource].
 //
 // Transport is a low-level mechanism. Most code will use the
-// higher-level Config.Client method instead.
+// higher-level [Config.Client] method instead.
 type Transport struct {
 	// Source supplies the token to add to outgoing requests'
 	// Authorization headers.
@@ -47,7 +47,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	req2 := cloneRequest(req) // per RoundTripper contract
+	req2 := req.Clone(req.Context())
 	token.SetAuthHeader(req2)
 
 	// req.Body is assumed to be closed by the base RoundTripper.
@@ -72,18 +72,4 @@ func (t *Transport) base() http.RoundTripper {
 		return t.Base
 	}
 	return http.DefaultTransport
-}
-
-// cloneRequest returns a clone of the provided *http.Request.
-// The clone is a shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request) *http.Request {
-	// shallow copy of the struct
-	r2 := new(http.Request)
-	*r2 = *r
-	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-	return r2
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -137,7 +137,7 @@ github.com/JohnCGriffin/overflow
 # github.com/KimMachineGun/automemlimit v0.7.4
 ## explicit; go 1.22.0
 github.com/KimMachineGun/automemlimit/memlimit
-# github.com/Microsoft/go-winio v0.6.2 => github.com/microsoft/go-winio v0.6.2
+# github.com/Microsoft/go-winio v0.6.2
 ## explicit; go 1.21
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/internal/fs
@@ -548,7 +548,7 @@ github.com/envoyproxy/go-control-plane/envoy/type/v3
 # github.com/envoyproxy/protoc-gen-validate v1.2.1
 ## explicit; go 1.21.1
 github.com/envoyproxy/protoc-gen-validate/validate
-# github.com/expr-lang/expr v1.17.5 => github.com/expr-lang/expr v1.17.0
+# github.com/expr-lang/expr v1.17.5
 ## explicit; go 1.18
 github.com/expr-lang/expr
 github.com/expr-lang/expr/ast
@@ -2603,7 +2603,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/envconfig
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry
-# go.opentelemetry.io/otel/exporters/prometheus v0.59.0
+# go.opentelemetry.io/otel/exporters/prometheus v0.59.0 => go.opentelemetry.io/otel/exporters/prometheus v0.58.0
 ## explicit; go 1.23.0
 go.opentelemetry.io/otel/exporters/prometheus
 # go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.13.0
@@ -2736,9 +2736,9 @@ golang.org/x/exp/slices
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/module
 golang.org/x/mod/semver
-# golang.org/x/net v0.29.0 => golang.org/x/net v0.38.0
+# golang.org/x/net v0.29.0
 ## explicit; go 1.23.0
-# golang.org/x/net v0.42.0 => golang.org/x/net v0.38.0
+# golang.org/x/net v0.42.0
 ## explicit; go 1.23.0
 golang.org/x/net/bpf
 golang.org/x/net/context
@@ -2761,7 +2761,7 @@ golang.org/x/net/netutil
 golang.org/x/net/proxy
 golang.org/x/net/publicsuffix
 golang.org/x/net/trace
-# golang.org/x/oauth2 v0.30.0 => golang.org/x/oauth2 v0.27.0
+# golang.org/x/oauth2 v0.30.0
 ## explicit; go 1.23.0
 golang.org/x/oauth2
 golang.org/x/oauth2/authhandler
@@ -3489,7 +3489,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/Microsoft/go-winio => github.com/microsoft/go-winio v0.6.2
-# github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.0
-# golang.org/x/net => golang.org/x/net v0.38.0
-# golang.org/x/oauth2 => golang.org/x/oauth2 v0.27.0
+# go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0


### PR DESCRIPTION
Context: https://github.com/open-telemetry/opentelemetry-collector/pull/13466

go.opentelemetry.io/otel/exporters/prometheus v0.59.x has a bug leading to unexpected suffix in metric names, we need to stay with v0.58.0 to make `observe-agent status` work.