### PR TITLE
Move timeout from 25 minutes to 35 minutes

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run GoReleaser
-        timeout-minutes: 25
+        timeout-minutes: 35
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Run GoReleaser
-        timeout-minutes: 25
+        timeout-minutes: 35
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro


### PR DESCRIPTION
### Description

[OBSSD-1445](https://observe.atlassian.net/browse/OBSSD-1445) changing the goreleaser timeout since we just had it time out.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

[OBSSD-1445]: https://observe.atlassian.net/browse/OBSSD-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ