### PR TITLE
fix: Continue setting env vars even when agentresource creation fails

### DIFF
--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -126,7 +126,7 @@ func setEnvVars() error {
 	// Initialize agent resource to get/generate agent instance ID
 	agentRes, err := agentresource.New()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not instantiate agent resource: %w\n", err)
+		fmt.Fprintf(os.Stderr, "Could not instantiate agent resource: %v\n", err)
 	} else {
 		// Set agent instance ID as environment variable
 		os.Setenv("OBSERVE_AGENT_INSTANCE_ID", agentRes.GetAgentInstanceId())


### PR DESCRIPTION
### Description

OB-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary