### PR TITLE
fix(connections): render otel configs in memory and sweep legacy temp dirs

### DIFF
--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -48,10 +48,7 @@ var configValidateCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := logger.WithCtx(context.Background(), logger.GetNop())
-		col, cleanup, err := observecol.GetOtelCollector(ctx)
-		if cleanup != nil {
-			defer cleanup()
-		}
+		col, err := observecol.GetOtelCollector(ctx)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "❌ failed to generate config")
 			return err

--- a/internal/commands/config/config_test.go
+++ b/internal/commands/config/config_test.go
@@ -149,10 +149,7 @@ func runValidateTest(t *testing.T, test snapshotTest) {
 
 	// Run the test
 	ctx := logger.WithCtx(context.Background(), logger.GetNop())
-	col, cleanup, err := observecol.GetOtelCollector(ctx)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	col, err := observecol.GetOtelCollector(ctx)
 	assert.NoError(t, err)
 	err = col.DryRun(ctx)
 	assert.NoError(t, err)

--- a/internal/commands/config/printers.go
+++ b/internal/commands/config/printers.go
@@ -18,10 +18,7 @@ import (
 )
 
 func PrintAllConfigsIndividually(ctx context.Context, w io.Writer) error {
-	configFilePaths, cleanup, err := connections.SetupAndGetConfigFiles(ctx)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	fragments, err := connections.SetupAndGetConfigs(ctx)
 	if err != nil {
 		return err
 	}
@@ -47,26 +44,22 @@ func PrintAllConfigsIndividually(ctx context.Context, w io.Writer) error {
 		return err
 	}
 	printConfig("computed agent config", agentConfigYaml)
-	agentConfigFile := viper.ConfigFileUsed()
-	if agentConfigFile != "" {
-		configFilePaths = append([]string{agentConfigFile}, configFilePaths...)
-	}
-	for _, filePath := range configFilePaths {
-		file, err := os.ReadFile(filePath)
+	if agentConfigFile := viper.ConfigFileUsed(); agentConfigFile != "" {
+		file, err := os.ReadFile(agentConfigFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error reading config file %s: %s", filePath, err.Error())
+			fmt.Fprintf(os.Stderr, "error reading config file %s: %s", agentConfigFile, err.Error())
 		} else {
-			printConfig("config file "+filePath, file)
+			printConfig("config file "+agentConfigFile, file)
 		}
+	}
+	for _, f := range fragments {
+		printConfig("config fragment "+f.Name, []byte(f.Content))
 	}
 	return nil
 }
 
 func PrintShortOtelConfig(ctx context.Context, w io.Writer) error {
-	settings, cleanup, err := observecol.GetOtelCollectorSettings(ctx)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	settings, err := observecol.GetOtelCollectorSettings(ctx)
 	if err != nil {
 		return err
 	}
@@ -90,10 +83,7 @@ func PrintShortOtelConfig(ctx context.Context, w io.Writer) error {
 }
 
 func PrintFullOtelConfig(ctx context.Context, w io.Writer) error {
-	settings, cleanup, err := observecol.GetOtelCollectorSettings(ctx)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	settings, err := observecol.GetOtelCollectorSettings(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/diagnose/otelconfigcheck.go
+++ b/internal/commands/diagnose/otelconfigcheck.go
@@ -16,10 +16,7 @@ type OtelConfigTestResult struct {
 
 func checkOtelConfig(_ *viper.Viper) (bool, any, error) {
 	ctx := logger.WithCtx(context.Background(), logger.GetNop())
-	col, cleanup, err := observecol.GetOtelCollector(ctx)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	col, err := observecol.GetOtelCollector(ctx)
 	if err != nil {
 		return false, nil, err
 	}

--- a/internal/commands/start/start.go
+++ b/internal/commands/start/start.go
@@ -62,10 +62,7 @@ collector on the current host.`,
 			if err := setConfigEnvVars(ctx); err != nil {
 				logger.FromCtx(ctx).Error("failed to set observe-agent config env vars, attempting to start anyway", zap.Error(err))
 			}
-			col, cleanup, err := observecol.GetOtelCollector(ctx)
-			if cleanup != nil {
-				defer cleanup()
-			}
+			col, err := observecol.GetOtelCollector(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/connections/confighandler.go
+++ b/internal/connections/confighandler.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/observeinc/observe-agent/internal/commands/util/logger"
 	"github.com/observeinc/observe-agent/internal/config"
-	"github.com/observeinc/observe-agent/internal/utils"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,38 +18,26 @@ const (
 	OTEL_OVERRIDE_YAML_KEY = "otel_config_overrides"
 )
 
-func SetupAndGetConfigFiles(ctx context.Context) ([]string, func(), error) {
-	// Set up our temp dir and temp config files
-	tmpDir, err := os.MkdirTemp("", TempFilesFolder)
-	if err != nil {
-		return nil, nil, err
-	}
-	cleanup := func() {
-		os.RemoveAll(tmpDir)
-	}
-	configFilePaths, err := getAllOtelConfigFilePaths(ctx, tmpDir)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	return configFilePaths, cleanup, nil
-}
+// SetupAndGetConfigs renders every enabled otel config fragment in memory
+// and returns them. It also sweeps any legacy on-disk config temp dirs left
+// behind by older agent versions. See CleanupLegacyTempDirs.
+func SetupAndGetConfigs(ctx context.Context) ([]RenderedConfigFragment, error) {
+	CleanupLegacyTempDirs(ctx)
 
-func getAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, error) {
-	configFilePaths := []string{}
-	// Get additional config paths based on connection configs
 	agentConfig, err := config.AgentConfigFromViper(viper.GetViper())
 	if err != nil {
 		return nil, err
 	}
+
+	fragments := make([]RenderedConfigFragment, 0)
 	for _, conn := range AllConnectionTypes {
-		connectionPaths, err := conn.GetBundledConfigs(ctx, tmpDir, agentConfig)
+		connFragments, err := conn.GetBundledConfigs(ctx, agentConfig)
 		if err != nil {
 			return nil, err
 		}
-		configFilePaths = append(configFilePaths, connectionPaths...)
+		fragments = append(fragments, connFragments...)
 	}
-	// Generate override file and include path if overrides provided
+
 	if viper.IsSet(OTEL_OVERRIDE_YAML_KEY) {
 		// GetStringMap is more lenient with respect to conversions than Sub, which only handles maps.
 		overrides := viper.GetStringMap(OTEL_OVERRIDE_YAML_KEY)
@@ -58,45 +47,141 @@ func getAllOtelConfigFilePaths(ctx context.Context, tmpDir string) ([]string, er
 			if stringData != "" {
 				// Viper can handle overrides set in the agent config, or passed in as an env var as a JSON string.
 				// For consistency, we also want to accept an env var as a YAML string.
-				err := yaml.Unmarshal([]byte(stringData), &overrides)
-				if err != nil {
+				if err := yaml.Unmarshal([]byte(stringData), &overrides); err != nil {
 					return nil, fmt.Errorf("%s was provided but could not be parsed", OTEL_OVERRIDE_YAML_KEY)
 				}
 			}
 		}
-		// Only create the config file if there are overrides present (ie ignore empty maps)
+		// Only build an override fragment if there are overrides present
+		// (ie ignore empty maps).
 		if len(overrides) != 0 {
-			overridePath, err := getOverrideConfigFile(tmpDir, overrides)
+			override, err := buildOverrideConfigFragment(overrides)
 			if err != nil {
 				return nil, err
 			}
-			configFilePaths = append(configFilePaths, overridePath)
+			fragments = append(fragments, override)
 		}
 	}
-	logger.FromCtx(ctx).Debug(fmt.Sprint("Config file paths:", configFilePaths))
-	return configFilePaths, nil
+
+	if l := logger.FromCtx(ctx); l != nil {
+		names := make([]string, 0, len(fragments))
+		for _, f := range fragments {
+			names = append(names, f.Name)
+		}
+		l.Debug("rendered otel config fragments", zap.Strings("fragments", names))
+	}
+	return fragments, nil
 }
 
-func getOverrideConfigFile(tmpDir string, data map[string]any) (string, error) {
-	f, err := os.CreateTemp(tmpDir, "otel-config-overrides-*.yaml")
-	if err != nil {
-		return "", fmt.Errorf("failed to create config file to write to: %w", err)
-	}
+func buildOverrideConfigFragment(data map[string]any) (RenderedConfigFragment, error) {
 	contents, err := yaml.Marshal(data)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal otel config overrides: %w", err)
+		return RenderedConfigFragment{}, fmt.Errorf("failed to marshal otel config overrides: %w", err)
 	}
-	_, err = f.Write([]byte(contents))
+	return RenderedConfigFragment{Name: "otel-config-overrides.yaml", Content: string(contents)}, nil
+}
+
+func isLegacyTempDirName(name string) bool {
+	if !strings.HasPrefix(name, TempFilesFolder) {
+		return false
+	}
+	suffix := strings.TrimPrefix(name, TempFilesFolder)
+	if suffix == "" {
+		return false
+	}
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// classifyLegacyConfigTempDir reports whether a candidate directory looks like
+// a legacy config temp dir, and if not, returns a human-readable reason
+// suitable for debug logging.
+func classifyLegacyConfigTempDir(path string) (match bool, reason string) {
+	entries, err := os.ReadDir(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to write otel config overrides to file: %w", err)
+		return false, fmt.Sprintf("cannot read directory: %s", err.Error())
 	}
-	return f.Name(), nil
+	// Empty dirs match: the flat-and-YAML-only rule is vacuously true.
+	if len(entries) == 0 {
+		return true, ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return false, fmt.Sprintf("contains subdirectory %q (legacy config dirs were flat)", entry.Name())
+		}
+		if !strings.HasSuffix(entry.Name(), ".yaml") {
+			return false, fmt.Sprintf("contains non-YAML file %q", entry.Name())
+		}
+	}
+	return true, ""
 }
 
-func GetConfigFragmentFolderPath() string {
-	return filepath.Join(utils.GetDefaultAgentPath(), "connections")
+// CleanupLegacyTempDirs removes directories in os.TempDir() whose names
+// match `<TempFilesFolder><numeric-suffix>` and whose contents are either
+// empty or only YAML files. The sweep is best-effort and non-fatal; all
+// outcomes are emitted as structured logs.
+func CleanupLegacyTempDirs(ctx context.Context) {
+	cleanupLegacyTempDirsIn(ctx, os.TempDir())
 }
 
-func GetDefaultAgentPath() string {
-	return utils.GetDefaultAgentPath()
+func cleanupLegacyTempDirsIn(ctx context.Context, root string) {
+	log := logger.FromCtx(ctx)
+	log.Debug("scanning temp directory for legacy observe-agent config directories",
+		zap.String("temp_dir", root))
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		log.Warn("failed to scan temp directory for legacy observe-agent config directories",
+			zap.String("temp_dir", root), zap.Error(err))
+		return
+	}
+
+	var scanned, matched, removed, failed, skipped int
+	for _, entry := range entries {
+		scanned++
+		if !entry.IsDir() || !isLegacyTempDirName(entry.Name()) {
+			continue
+		}
+		matched++
+		p := filepath.Join(root, entry.Name())
+
+		ok, reason := classifyLegacyConfigTempDir(p)
+		if !ok {
+			skipped++
+			log.Debug("skipping candidate temp directory",
+				zap.String("path", p), zap.String("reason", reason))
+			continue
+		}
+
+		if err := os.RemoveAll(p); err != nil {
+			failed++
+			log.Warn("failed to remove legacy observe-agent temp directory",
+				zap.String("path", p), zap.Error(err))
+			continue
+		}
+		removed++
+		log.Info("removed legacy observe-agent temp directory", zap.String("path", p))
+	}
+
+	fields := []zap.Field{
+		zap.String("temp_dir", root),
+		zap.Int("scanned", scanned),
+		zap.Int("matched", matched),
+		zap.Int("removed", removed),
+		zap.Int("failed", failed),
+		zap.Int("skipped", skipped),
+	}
+	const summaryMsg = "legacy observe-agent temp directory cleanup finished"
+	switch {
+	case failed > 0:
+		log.Warn(summaryMsg, fields...)
+	case removed > 0:
+		log.Info(summaryMsg, fields...)
+	default:
+		log.Debug(summaryMsg, fields...)
+	}
 }

--- a/internal/connections/confighandler_test.go
+++ b/internal/connections/confighandler_test.go
@@ -1,0 +1,356 @@
+package connections
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/observeinc/observe-agent/internal/commands/util/logger"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"gopkg.in/yaml.v3"
+)
+
+func collectTempDirsWithPrefix(t *testing.T, prefix string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(os.TempDir())
+	require.NoError(t, err)
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), prefix) {
+			dirs = append(dirs, filepath.Join(os.TempDir(), entry.Name()))
+		}
+	}
+	return dirs
+}
+
+func setupTestViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	viper.Set("token", "test:token123456789")
+	viper.Set("observe_url", "https://example.observeinc.com")
+	t.Cleanup(func() { viper.Reset() })
+}
+
+// observedLoggerCtx returns a context with a logger that records entries at
+// debug+ so tests can assert on structured log output.
+func observedLoggerCtx(t *testing.T) (context.Context, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	l := zap.New(core)
+	return logger.WithCtx(context.Background(), l), logs
+}
+
+// findLog returns the first log entry with the given message, or nil.
+func findLog(logs *observer.ObservedLogs, msg string) *observer.LoggedEntry {
+	for _, e := range logs.All() {
+		if e.Message == msg {
+			entry := e
+			return &entry
+		}
+	}
+	return nil
+}
+
+// TestSetupAndGetConfigs_DoesNotCreateTempDirs asserts that repeated calls
+// to SetupAndGetConfigs do not create any observe-agent* directories in
+// os.TempDir().
+func TestSetupAndGetConfigs_DoesNotCreateTempDirs(t *testing.T) {
+	setupTestViper(t)
+	ctx := logger.WithCtx(context.Background(), logger.GetNop())
+
+	before := collectTempDirsWithPrefix(t, TempFilesFolder)
+
+	for i := 0; i < 3; i++ {
+		fragments, err := SetupAndGetConfigs(ctx)
+		require.NoError(t, err, "SetupAndGetConfigs call %d should succeed", i)
+		require.NotEmpty(t, fragments)
+		for _, f := range fragments {
+			assert.NotEmpty(t, f.Name)
+			assert.NotEmpty(t, f.Content)
+		}
+	}
+
+	after := collectTempDirsWithPrefix(t, TempFilesFolder)
+	assert.ElementsMatch(t, before, after,
+		"SetupAndGetConfigs must not create any observe-agent* temp dirs (before=%v after=%v)", before, after)
+}
+
+// TestCleanupLegacyTempDirs_RemovesOrphans asserts CleanupLegacyTempDirs
+// removes observe-agent*<numeric> directories whose contents are YAML
+// fragments.
+func TestCleanupLegacyTempDirs_RemovesOrphans(t *testing.T) {
+	ctx := logger.WithCtx(context.Background(), logger.GetNop())
+
+	orphans := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		dir, err := os.MkdirTemp("", TempFilesFolder)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "fragment.yaml"), []byte("x: 1\n"), 0o600))
+		orphans = append(orphans, dir)
+	}
+	t.Cleanup(func() {
+		for _, d := range orphans {
+			os.RemoveAll(d)
+		}
+	})
+
+	CleanupLegacyTempDirs(ctx)
+
+	for _, d := range orphans {
+		_, err := os.Stat(d)
+		assert.True(t, os.IsNotExist(err),
+			"legacy temp dir %s should have been removed by CleanupLegacyTempDirs, got err=%v", d, err)
+	}
+}
+
+// TestCleanupLegacyTempDirs_RunViaSetup asserts SetupAndGetConfigs invokes
+// CleanupLegacyTempDirs.
+func TestCleanupLegacyTempDirs_RunViaSetup(t *testing.T) {
+	setupTestViper(t)
+	ctx := logger.WithCtx(context.Background(), logger.GetNop())
+
+	dir, err := os.MkdirTemp("", TempFilesFolder)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fragment.yaml"), []byte("x: 1\n"), 0o600))
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	_, err = SetupAndGetConfigs(ctx)
+	require.NoError(t, err)
+
+	_, err = os.Stat(dir)
+	assert.True(t, os.IsNotExist(err),
+		"legacy temp dir %s should have been cleaned up by SetupAndGetConfigs", dir)
+}
+
+// TestCleanupLegacyTempDirs_DoesNotRemoveNonLegacyPrefixedDirs asserts dirs
+// sharing the observe-agent prefix but not matching the numeric-suffix
+// naming format are preserved.
+func TestCleanupLegacyTempDirs_DoesNotRemoveNonLegacyPrefixedDirs(t *testing.T) {
+	ctx := logger.WithCtx(context.Background(), logger.GetNop())
+
+	nonLegacy := filepath.Join(os.TempDir(), TempFilesFolder+"-unrelated-"+t.Name())
+	require.NoError(t, os.Mkdir(nonLegacy, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nonLegacy, "keep.txt"), []byte("keep"), 0o600))
+	t.Cleanup(func() { os.RemoveAll(nonLegacy) })
+
+	CleanupLegacyTempDirs(ctx)
+
+	_, err := os.Stat(nonLegacy)
+	assert.NoError(t, err, "non-legacy prefixed dir %s should not be removed", nonLegacy)
+}
+
+// TestCleanupLegacyTempDirs_DoesNotRemoveNumericPrefixedNonConfigDirs
+// asserts numeric-suffixed dirs whose contents are not YAML-only are
+// preserved.
+func TestCleanupLegacyTempDirs_DoesNotRemoveNumericPrefixedNonConfigDirs(t *testing.T) {
+	ctx := logger.WithCtx(context.Background(), logger.GetNop())
+
+	nonConfig := filepath.Join(os.TempDir(), TempFilesFolder+"123456789")
+	require.NoError(t, os.Mkdir(nonConfig, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nonConfig, "keep.txt"), []byte("keep"), 0o600))
+	t.Cleanup(func() { os.RemoveAll(nonConfig) })
+
+	CleanupLegacyTempDirs(ctx)
+
+	_, err := os.Stat(nonConfig)
+	assert.NoError(t, err, "numeric prefixed non-config dir %s should not be removed", nonConfig)
+}
+
+// TestCleanupLegacyTempDirs_LogsStartAndSummary asserts start, per-removal,
+// and summary log entries are emitted with their expected fields.
+func TestCleanupLegacyTempDirs_LogsStartAndSummary(t *testing.T) {
+	ctx, logs := observedLoggerCtx(t)
+	root := t.TempDir()
+
+	legacy := filepath.Join(root, TempFilesFolder+"42")
+	require.NoError(t, os.Mkdir(legacy, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "fragment.yaml"), []byte("x: 1\n"), 0o600))
+
+	cleanupLegacyTempDirsIn(ctx, root)
+
+	start := findLog(logs, "scanning temp directory for legacy observe-agent config directories")
+	require.NotNil(t, start, "expected a start log entry")
+	assert.Equal(t, root, start.ContextMap()["temp_dir"])
+
+	removed := findLog(logs, "removed legacy observe-agent temp directory")
+	require.NotNil(t, removed, "expected a per-directory removal log entry")
+	assert.Equal(t, legacy, removed.ContextMap()["path"])
+
+	summary := findLog(logs, "legacy observe-agent temp directory cleanup finished")
+	require.NotNil(t, summary, "expected a summary log entry")
+	ctxMap := summary.ContextMap()
+	assert.EqualValues(t, 1, ctxMap["removed"])
+	assert.EqualValues(t, 0, ctxMap["failed"])
+}
+
+// TestCleanupLegacyTempDirs_LogsSkipReason asserts skipped candidates are
+// logged with a non-empty `reason` field.
+func TestCleanupLegacyTempDirs_LogsSkipReason(t *testing.T) {
+	ctx, logs := observedLoggerCtx(t)
+	root := t.TempDir()
+
+	nonConfig := filepath.Join(root, TempFilesFolder+"7")
+	require.NoError(t, os.Mkdir(nonConfig, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nonConfig, "keep.txt"), []byte("keep"), 0o600))
+
+	cleanupLegacyTempDirsIn(ctx, root)
+
+	skip := findLog(logs, "skipping candidate temp directory")
+	require.NotNil(t, skip, "expected a skip log entry for numeric non-config dir")
+	ctxMap := skip.ContextMap()
+	assert.Equal(t, nonConfig, ctxMap["path"])
+	assert.NotEmpty(t, ctxMap["reason"], "skip log entry must include a reason")
+}
+
+// TestCleanupLegacyTempDirs_LogsFailure asserts a warn-level log entry with
+// `path` and `error` fields is emitted when removal fails.
+func TestCleanupLegacyTempDirs_LogsFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based failure cannot be simulated when running as root")
+	}
+
+	ctx, logs := observedLoggerCtx(t)
+	root := t.TempDir()
+
+	legacy := filepath.Join(root, TempFilesFolder+"99")
+	require.NoError(t, os.Mkdir(legacy, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "fragment.yaml"), []byte("x: 1\n"), 0o600))
+	require.NoError(t, os.Chmod(root, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(root, 0o700) })
+
+	cleanupLegacyTempDirsIn(ctx, root)
+
+	failLog := findLog(logs, "failed to remove legacy observe-agent temp directory")
+	require.NotNil(t, failLog, "expected a failure log entry when removal is not permitted")
+	ctxMap := failLog.ContextMap()
+	assert.Equal(t, legacy, ctxMap["path"])
+	assert.NotEmpty(t, ctxMap["error"], "failure log entry must include the underlying error")
+	assert.GreaterOrEqual(t, failLog.Level, zapcore.WarnLevel,
+		"failure log entry should be at Warn level or higher")
+}
+
+// findOverrideFragment returns the rendered otel_config_overrides fragment
+// from a fragment list, or nil if none is present.
+func findOverrideFragment(fragments []RenderedConfigFragment) *RenderedConfigFragment {
+	const name = "otel-config-overrides.yaml"
+	for i := range fragments {
+		if fragments[i].Name == name {
+			return &fragments[i]
+		}
+	}
+	return nil
+}
+
+// TestSetupAndGetConfigs_OtelOverridePaths covers the viper delivery paths
+// for otel_config_overrides: native map via viper.Set, JSON string env var
+// (auto-coerced by GetStringMap), YAML string env var (falls through to
+// yaml.Unmarshal), empty env var (ignored), and invalid YAML (error).
+func TestSetupAndGetConfigs_OtelOverridePaths(t *testing.T) {
+	want := map[string]any{
+		"exporters": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "example.com:4317",
+			},
+		},
+	}
+
+	type setMode int
+	const (
+		setUnset setMode = iota
+		setMap           // inject via viper.Set (native-map path)
+		setEnv           // inject via env var + viper.AutomaticEnv
+	)
+
+	cases := []struct {
+		name          string
+		mode          setMode
+		mapValue      map[string]any
+		envValue      string
+		wantFragment  bool
+		wantOverrides map[string]any
+		wantErrSubstr string
+	}{
+		{
+			name:         "unset produces no override fragment",
+			mode:         setUnset,
+			wantFragment: false,
+		},
+		{
+			name:          "native map from config is used directly",
+			mode:          setMap,
+			mapValue:      map[string]any{"exporters": map[string]any{"otlp": map[string]any{"endpoint": "example.com:4317"}}},
+			wantFragment:  true,
+			wantOverrides: want,
+		},
+		{
+			name:          "JSON string env-var is coerced by GetStringMap",
+			mode:          setEnv,
+			envValue:      `{"exporters":{"otlp":{"endpoint":"example.com:4317"}}}`,
+			wantFragment:  true,
+			wantOverrides: want,
+		},
+		{
+			name:          "YAML string env-var falls through to yaml.Unmarshal",
+			mode:          setEnv,
+			envValue:      "exporters:\n  otlp:\n    endpoint: example.com:4317\n",
+			wantFragment:  true,
+			wantOverrides: want,
+		},
+		{
+			name:         "empty env-var is ignored",
+			mode:         setEnv,
+			envValue:     "",
+			wantFragment: false,
+		},
+		{
+			name:          "invalid YAML env-var returns parse error",
+			mode:          setEnv,
+			envValue:      "exporters:\n  otlp: [unterminated",
+			wantErrSubstr: OTEL_OVERRIDE_YAML_KEY + " was provided but could not be parsed",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			setupTestViper(t)
+			switch c.mode {
+			case setMap:
+				viper.Set(OTEL_OVERRIDE_YAML_KEY, c.mapValue)
+			case setEnv:
+				// AutomaticEnv + OTEL_CONFIG_OVERRIDES is the production
+				// env-var path; unlike viper.Set it does not feed Unmarshal.
+				t.Setenv("OTEL_CONFIG_OVERRIDES", c.envValue)
+				viper.AutomaticEnv()
+			}
+
+			ctx := logger.WithCtx(context.Background(), logger.GetNop())
+			fragments, err := SetupAndGetConfigs(ctx)
+
+			if c.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+
+			got := findOverrideFragment(fragments)
+			if !c.wantFragment {
+				assert.Nil(t, got, "expected no override fragment")
+				return
+			}
+			require.NotNil(t, got, "expected override fragment to be present")
+
+			var decoded map[string]any
+			require.NoError(t, yaml.Unmarshal([]byte(got.Content), &decoded),
+				"override fragment content must be valid YAML")
+			assert.Equal(t, c.wantOverrides, decoded)
+		})
+	}
+}

--- a/internal/connections/connections.go
+++ b/internal/connections/connections.go
@@ -1,10 +1,10 @@
 package connections
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"text/template"
@@ -16,7 +16,19 @@ import (
 	"go.uber.org/zap"
 )
 
+// TempFilesFolder is the name prefix CleanupLegacyTempDirs uses to identify
+// legacy observe-agent config directories in os.TempDir().
 var TempFilesFolder = "observe-agent"
+
+// RenderedConfigFragment is an otel config fragment held in memory and
+// passed to the otelcol resolver via an inline `yaml:` URI.
+type RenderedConfigFragment struct {
+	// Name is a human-readable identifier used for logging and for the
+	// `config print` command headers (e.g. `host_monitoring-host_metrics.yaml`).
+	Name string
+	// Content is the rendered YAML body of the fragment.
+	Content string
+}
 
 type EnabledCheckFn func(*config.AgentConfig) bool
 
@@ -45,55 +57,49 @@ func (c *ConnectionType) getTemplate(tplName string) (*template.Template, error)
 	return template.New(path.Base(tplName)).Funcs(utils.TemplateFuncs()).ParseFS(fs, tplName)
 }
 
-func renderBundledConfigTemplate(ctx context.Context, tmpDir string, outFileName string, tmpl *template.Template, confValues any) (string, error) {
-	f, err := os.CreateTemp(tmpDir, fmt.Sprintf("*-%s", outFileName))
-	if err != nil {
-		logger.FromCtx(ctx).Error("failed to create temporary config fragment file", zap.String("fileName", outFileName), zap.Error(err))
+func renderBundledConfigTemplate(tmpl *template.Template, confValues any) (string, error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, confValues); err != nil {
 		return "", err
 	}
-	err = tmpl.Execute(f, confValues)
-	if err != nil {
-		logger.FromCtx(ctx).Error("failed to execute config fragment template", zap.String("fileName", outFileName), zap.Error(err))
-		return "", err
-	}
-	return f.Name(), nil
+	return buf.String(), nil
 }
 
-func (c *ConnectionType) renderBundledConfigTemplate(ctx context.Context, tmpDir string, tplName string, confValues any) (string, error) {
+func (c *ConnectionType) renderBundledConfigTemplate(ctx context.Context, tplName string, confValues any) (RenderedConfigFragment, error) {
 	tmpl, err := c.getTemplate(c.Name + "/" + tplName)
 	if err != nil {
-		fmt.Printf("TODO err1: %s\n", err.Error())
-		return "", err
+		return RenderedConfigFragment{}, err
 	}
-	outFileName := c.Name + "-" + strings.TrimSuffix(tplName, ".tmpl")
-	return renderBundledConfigTemplate(ctx, tmpDir, outFileName, tmpl, confValues)
+	content, err := renderBundledConfigTemplate(tmpl, confValues)
+	if err != nil {
+		logger.FromCtx(ctx).Error("failed to execute config fragment template", zap.String("tplName", tplName), zap.Error(err))
+		return RenderedConfigFragment{}, err
+	}
+	name := c.Name + "-" + strings.TrimSuffix(tplName, ".tmpl")
+	return RenderedConfigFragment{Name: name, Content: content}, nil
 }
 
-func (c *ConnectionType) renderAllBundledConfigFragments(ctx context.Context, tmpDir string, agentConfig *config.AgentConfig) ([]string, error) {
-	paths := make([]string, 0)
+func (c *ConnectionType) renderAllBundledConfigFragments(ctx context.Context, agentConfig *config.AgentConfig) ([]RenderedConfigFragment, error) {
+	rendered := make([]RenderedConfigFragment, 0)
 	for _, fragment := range c.BundledConfigFragments {
 		if !fragment.enabledCheck(agentConfig) || fragment.colConfigFilePath == "" {
 			continue
 		}
-		configPath, err := c.renderBundledConfigTemplate(ctx, tmpDir, fragment.colConfigFilePath, agentConfig)
+		r, err := c.renderBundledConfigTemplate(ctx, fragment.colConfigFilePath, agentConfig)
 		if err != nil {
 			return nil, err
 		}
-		paths = append(paths, configPath)
+		rendered = append(rendered, r)
 	}
-	return paths, nil
+	return rendered, nil
 }
 
-func (c *ConnectionType) GetBundledConfigs(ctx context.Context, tmpDir string, agentConfig *config.AgentConfig) ([]string, error) {
+func (c *ConnectionType) GetBundledConfigs(ctx context.Context, agentConfig *config.AgentConfig) ([]RenderedConfigFragment, error) {
 	if !c.EnabledCheck(agentConfig) {
-		return []string{}, nil
+		return []RenderedConfigFragment{}, nil
 	}
 
-	configPaths, err := c.renderAllBundledConfigFragments(ctx, tmpDir, agentConfig)
-	if err != nil {
-		return nil, err
-	}
-	return configPaths, nil
+	return c.renderAllBundledConfigFragments(ctx, agentConfig)
 }
 
 type ConnectionTypeOption func(*ConnectionType)

--- a/internal/connections/connections_test.go
+++ b/internal/connections/connections_test.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/observeinc/observe-agent/internal/commands/util/logger"
@@ -29,7 +28,6 @@ var TestTemplateOverrides = map[string]embed.FS{
 
 type ConnectionsTestSuite struct {
 	suite.Suite
-	tempDir         string
 	configFilesPath string
 	ctx             context.Context
 }
@@ -37,17 +35,9 @@ type ConnectionsTestSuite struct {
 func (suite *ConnectionsTestSuite) SetupSuite() {
 	suite.ctx = logger.WithCtx(context.Background(), logger.Get())
 
-	tempDir, err := os.MkdirTemp("", "test-connections")
-	suite.NoError(err)
-	suite.tempDir = tempDir
-
 	_, filename, _, ok := runtime.Caller(0)
 	suite.True(ok)
 	suite.configFilesPath = path.Dir(filename)
-}
-
-func (suite *ConnectionsTestSuite) TearDownSuite() {
-	os.RemoveAll(suite.tempDir)
 }
 
 func (suite *ConnectionsTestSuite) MakeConnectionType(configFields []BundledConfigFragment, enableCheck EnabledCheckFn) *ConnectionType {
@@ -88,17 +78,15 @@ func (suite *ConnectionsTestSuite) TestConnections_RenderConfigTemplate() {
 			C: []string{"test1", "test2", "test3"},
 		},
 	}
-	result, err := ct.renderBundledConfigTemplate(suite.ctx, suite.tempDir, "testHelloWorld.tpl", confValues)
+	result, err := ct.renderBundledConfigTemplate(suite.ctx, "testHelloWorld.tpl", confValues)
 
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.NotEmpty(result.Content)
+	suite.Equal("test-testHelloWorld.tpl", result.Name)
 
-	// Read the rendered content
-	renderedContent, err := os.ReadFile(result)
-	suite.NoError(err)
 	expectedContent, err := os.ReadFile(filepath.Join(suite.configFilesPath, "test", "testHelloWorld.yaml"))
 	suite.NoError(err)
-	suite.Equal(string(expectedContent), string(renderedContent))
+	suite.Equal(string(expectedContent), result.Content)
 }
 
 func (suite *ConnectionsTestSuite) TestConnectionType_ProcessConfigFields() {
@@ -113,13 +101,12 @@ func (suite *ConnectionsTestSuite) TestConnectionType_ProcessConfigFields() {
 		{enabledCheck: func(ac *config.AgentConfig) bool { return ac.Forwarding.Enabled }, colConfigFilePath: ""},
 	}, alwaysEnabled)
 
-	paths, err := ct.renderAllBundledConfigFragments(suite.ctx, suite.tempDir, &agentConfig)
+	fragments, err := ct.renderAllBundledConfigFragments(suite.ctx, &agentConfig)
 	suite.NoError(err)
 
-	suite.Len(paths, 1)
-	tmpFile := paths[0]
-	tmpConfName := tmpFile[strings.LastIndex(tmpFile, "-")+1:]
-	suite.Equal(ct.BundledConfigFragments[0].colConfigFilePath, tmpConfName)
+	suite.Len(fragments, 1)
+	suite.Equal("test-"+ct.BundledConfigFragments[0].colConfigFilePath, fragments[0].Name)
+	suite.NotEmpty(fragments[0].Content)
 }
 
 func (suite *ConnectionsTestSuite) TestConnectionType_GetConfigFilePaths() {
@@ -135,16 +122,14 @@ func (suite *ConnectionsTestSuite) TestConnectionType_GetConfigFilePaths() {
 		{enabledCheck: func(ac *config.AgentConfig) bool { return ac.Forwarding.Enabled }, colConfigFilePath: ""},
 	}, func(ac *config.AgentConfig) bool { return ac.Debug })
 
-	paths, err := ct.GetBundledConfigs(suite.ctx, suite.tempDir, &agentConfig)
+	fragments, err := ct.GetBundledConfigs(suite.ctx, &agentConfig)
 	suite.NoError(err)
-	suite.Len(paths, 1)
-	tmpFile := paths[0]
-	tmpConfName := tmpFile[strings.LastIndex(tmpFile, "-")+1:]
-	suite.Equal(ct.BundledConfigFragments[0].colConfigFilePath, tmpConfName)
+	suite.Len(fragments, 1)
+	suite.Equal("test-"+ct.BundledConfigFragments[0].colConfigFilePath, fragments[0].Name)
 
 	// Does nothing if not enabled
 	agentConfig.Debug = false
-	paths, err = ct.GetBundledConfigs(suite.ctx, suite.tempDir, &agentConfig)
+	fragments, err = ct.GetBundledConfigs(suite.ctx, &agentConfig)
 	suite.NoError(err)
-	suite.Len(paths, 0)
+	suite.Len(fragments, 0)
 }

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -90,7 +90,7 @@ func InitConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(CfgFile)
 	} else {
-		viper.AddConfigPath(connections.GetDefaultAgentPath())
+		viper.AddConfigPath(utils.GetDefaultAgentPath())
 		viper.SetConfigType("yaml")
 		viper.SetConfigName("observe-agent")
 	}

--- a/main_windows.go
+++ b/main_windows.go
@@ -31,10 +31,7 @@ func run() error {
 	root.InitConfig()
 
 	// Get the collector settings along with our bundled config files.
-	colSettings, cleanup, err := observecol.GetOtelCollectorSettings(context.Background())
-	if cleanup != nil {
-		defer cleanup()
-	}
+	colSettings, err := observecol.GetOtelCollectorSettings(context.Background())
 	if err != nil {
 		return err
 	}

--- a/observecol/otelcollector.go
+++ b/observecol/otelcollector.go
@@ -44,32 +44,61 @@ func generateCollectorSettings(URIs []string) *otelcol.CollectorSettings {
 	return set
 }
 
-func GetOtelCollectorSettings(ctx context.Context) (*otelcol.CollectorSettings, func(), error) {
-	observeAgentConfigs, cleanup, err := connections.SetupAndGetConfigFiles(ctx)
-	if err != nil {
-		return nil, cleanup, err
+// buildResolverURIs assembles the heterogeneous URI list handed to the
+// otelcol confmap resolver. It appends, in order:
+//
+//  1. Each in-memory fragment as an inline `yaml:<body>` URI. Fragments are
+//     RenderedConfigFragment structs (no longer file paths), so every entry
+//     must be transformed before it can live alongside the string-typed
+//     otelConfigs / otelSets URIs. The yamlprovider's `yaml:` scheme is a
+//     marker, not an RFC 3986 URI: its Retrieve implementation strips the
+//     prefix and hands the remainder directly to yaml.Unmarshal, so no
+//     escaping or trimming is needed -- fragment Content is produced by our
+//     templates or by yaml.Marshal and is always well-formed YAML, and YAML
+//     is whitespace-tolerant.
+//  2. The user's `--config` flag values verbatim. Those are already URIs
+//     for the file/http/env providers.
+//  3. Each `--set key=value` flag expanded into an inline `yaml:` URI,
+//     using the same parsing as the upstream otelcol `set` flag.
+//
+// The result slice is pre-sized to the full final length so it does not
+// re-grow across the three append steps.
+func buildResolverURIs(fragments []connections.RenderedConfigFragment, otelConfigs, otelSets []string) ([]string, error) {
+	URIs := make([]string, 0, len(fragments)+len(otelConfigs)+len(otelSets))
+	for _, f := range fragments {
+		URIs = append(URIs, "yaml:"+f.Content)
 	}
-	URIs := append(observeAgentConfigs, otelConfigs...)
-	// This loop is copied directly from the otelcol `set` flag handling.
+	URIs = append(URIs, otelConfigs...)
 	for _, s := range otelSets {
 		idx := strings.Index(s, "=")
 		if idx == -1 {
-			return nil, cleanup, fmt.Errorf("Value provided to --set flag is missing equal sign: %s", s)
+			return nil, fmt.Errorf("Value provided to --set flag is missing equal sign: %s", s)
 		}
 		URIs = append(URIs, "yaml:"+strings.TrimSpace(strings.ReplaceAll(s[:idx], ".", "::"))+": "+strings.TrimSpace(s[idx+1:]))
 	}
-	return generateCollectorSettings(URIs), cleanup, nil
+	return URIs, nil
 }
 
-func GetOtelCollector(ctx context.Context) (*otelcol.Collector, func(), error) {
-	settings, cleanup, err := GetOtelCollectorSettings(ctx)
+func GetOtelCollectorSettings(ctx context.Context) (*otelcol.CollectorSettings, error) {
+	fragments, err := connections.SetupAndGetConfigs(ctx)
 	if err != nil {
-		return nil, cleanup, err
+		return nil, err
 	}
+	URIs, err := buildResolverURIs(fragments, otelConfigs, otelSets)
+	if err != nil {
+		return nil, err
+	}
+	return generateCollectorSettings(URIs), nil
+}
 
+func GetOtelCollector(ctx context.Context) (*otelcol.Collector, error) {
+	settings, err := GetOtelCollectorSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
 	col, err := otelcol.NewCollector(*settings)
 	if err != nil {
-		return nil, cleanup, err
+		return nil, err
 	}
-	return col, cleanup, nil
+	return col, nil
 }

--- a/observecol/otelcollector_test.go
+++ b/observecol/otelcollector_test.go
@@ -1,0 +1,187 @@
+package observecol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/observeinc/observe-agent/internal/connections"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
+	"gopkg.in/yaml.v3"
+)
+
+// TestBuildResolverURIs pins the URI list buildResolverURIs assembles:
+// fragments as `yaml:<body>` URIs, then --config values verbatim, then
+// --set flags expanded into inline yaml URIs.
+func TestBuildResolverURIs(t *testing.T) {
+	frag := func(content string) connections.RenderedConfigFragment {
+		return connections.RenderedConfigFragment{Name: "frag.yaml", Content: content}
+	}
+
+	cases := []struct {
+		name         string
+		fragments    []connections.RenderedConfigFragment
+		otelConfigs  []string
+		otelSets     []string
+		want         []string
+		wantErrExact string
+	}{
+		{
+			name: "all inputs empty produces empty uri list",
+			want: []string{},
+		},
+		{
+			name: "fragments are inlined via yaml: scheme in order",
+			fragments: []connections.RenderedConfigFragment{
+				frag("receivers:\n  otlp:\n    protocols: {}\n"),
+				frag("exporters:\n  otlp:\n    endpoint: a:4317\n"),
+			},
+			want: []string{
+				"yaml:receivers:\n  otlp:\n    protocols: {}\n",
+				"yaml:exporters:\n  otlp:\n    endpoint: a:4317\n",
+			},
+		},
+		{
+			name:        "otel config uris pass through verbatim",
+			otelConfigs: []string{"file:/path/to/a", "env:OTEL_THING"},
+			want:        []string{"file:/path/to/a", "env:OTEL_THING"},
+		},
+		{
+			name:     "simple set becomes inline yaml key-value",
+			otelSets: []string{"service=default"},
+			want:     []string{"yaml:service: default"},
+		},
+		{
+			name:     "dotted set keys are expanded with :: separator",
+			otelSets: []string{"processors.batch.timeout=2s"},
+			want:     []string{"yaml:processors::batch::timeout: 2s"},
+		},
+		{
+			name:     "set trims whitespace around both key and value",
+			otelSets: []string{"  processors.batch.timeout  =  2s  "},
+			want:     []string{"yaml:processors::batch::timeout: 2s"},
+		},
+		{
+			name:         "set without equals sign is rejected",
+			otelSets:     []string{"processors.batch.timeout"},
+			wantErrExact: "Value provided to --set flag is missing equal sign: processors.batch.timeout",
+		},
+		{
+			name: "combined inputs preserve the fragments-configs-sets order",
+			fragments: []connections.RenderedConfigFragment{
+				frag("exporters:\n  otlp:\n    endpoint: a:4317\n"),
+			},
+			otelConfigs: []string{"file:/etc/otel.yaml"},
+			otelSets:    []string{"service=test"},
+			want: []string{
+				"yaml:exporters:\n  otlp:\n    endpoint: a:4317\n",
+				"file:/etc/otel.yaml",
+				"yaml:service: test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := buildResolverURIs(c.fragments, c.otelConfigs, c.otelSets)
+			if c.wantErrExact != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, c.wantErrExact)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestBuildResolverURIs_FragmentURIsAreYamlProviderSafe feeds each fragment
+// URI that buildResolverURIs emits through the real yamlprovider and asserts
+// the decoded value matches the original Content, across multi-line YAML,
+// leading/trailing whitespace, values containing colons, and a realistic
+// yaml.Marshal output of a nested map.
+func TestBuildResolverURIs_FragmentURIsAreYamlProviderSafe(t *testing.T) {
+	marshal := func(t *testing.T, v map[string]any) string {
+		t.Helper()
+		b, err := yaml.Marshal(v)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	cases := []struct {
+		name    string
+		content string
+		want    any
+	}{
+		{
+			name:    "simple scalar map",
+			content: "foo: bar\n",
+			want:    map[string]any{"foo": "bar"},
+		},
+		{
+			name:    "multi-line nested map",
+			content: "exporters:\n  otlp:\n    endpoint: example.com:4317\n",
+			want: map[string]any{
+				"exporters": map[string]any{
+					"otlp": map[string]any{"endpoint": "example.com:4317"},
+				},
+			},
+		},
+		{
+			name:    "value with embedded colon",
+			content: "endpoint: https://example.com:4317\n",
+			want:    map[string]any{"endpoint": "https://example.com:4317"},
+		},
+		{
+			name:    "leading and trailing whitespace is tolerated",
+			content: "\n\n  foo: bar\n\n",
+			want:    map[string]any{"foo": "bar"},
+		},
+		{
+			name: "yaml.Marshal output of a realistic override map round-trips",
+			content: marshal(t, map[string]any{
+				"exporters": map[string]any{
+					"otlp": map[string]any{
+						"endpoint": "example.com:4317",
+						"headers":  map[string]any{"X-Custom": "v"},
+					},
+				},
+			}),
+			want: map[string]any{
+				"exporters": map[string]any{
+					"otlp": map[string]any{
+						"endpoint": "example.com:4317",
+						"headers":  map[string]any{"X-Custom": "v"},
+					},
+				},
+			},
+		},
+	}
+
+	provider := yamlprovider.NewFactory().Create(confmap.ProviderSettings{})
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			uris, err := buildResolverURIs(
+				[]connections.RenderedConfigFragment{{Name: "frag.yaml", Content: c.content}},
+				nil, nil,
+			)
+			require.NoError(t, err)
+			require.Len(t, uris, 1)
+			require.Equal(t, "yaml:"+c.content, uris[0],
+				"fragment URI must be a plain concat of the yaml: scheme and Content")
+
+			retrieved, err := provider.Retrieve(context.Background(), uris[0], nil)
+			require.NoError(t, err, "yamlprovider must accept the fragment URI without error")
+			raw, err := retrieved.AsRaw()
+			require.NoError(t, err)
+			assert.Equal(t, c.want, raw,
+				"fragment content must round-trip through the yamlprovider unchanged")
+		})
+	}
+}


### PR DESCRIPTION
### Description

Resolves OB-58302 (tmp files not getting cleaned up) and switches to in-memory config handling:
- Render otel config fragments in memory via inline `yaml:` URIs; fixes
  `/tmp/observe-agent*` leaks on SIGKILL/OOM (OBSSD-3516).
- Sweep legacy temp dirs on startup with a tight matcher (numeric suffix +
  YAML-only contents) so unrelated `/tmp` data is not touched.
- Add structured logs for scan, per-dir result with reason/error, and summary
  counts.


### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary