### PR TITLE
fix: default docker image to bind 0.0.0.0 instead of localhost

### DIFF
--- a/integration/modules/create_ec2/locals.tf
+++ b/integration/modules/create_ec2/locals.tf
@@ -89,7 +89,7 @@ locals {
 
     WINDOWS_SERVER_2016_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-06a75f880b0c3d158"
+      ami_id            = "ami-0088ff4697cc1e9ba"
       ami_description   = "Microsoft Windows Server 2016 with Desktop Experience Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120
@@ -102,7 +102,7 @@ locals {
 
     WINDOWS_SERVER_2019_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-01247eb566bed0535"
+      ami_id            = "ami-0153f6f233c92a33d"
       ami_description   = "Microsoft Windows Server 2019 with Desktop Experience Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120
@@ -114,7 +114,7 @@ locals {
 
      WINDOWS_SERVER_2022_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-04564b7046ccefe43"
+      ami_id            = "ami-06137cb527bfce12a"
       ami_description   = "Microsoft Windows Server 2022 Full Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120

--- a/integration/scripts/test_docker_networking.py
+++ b/integration/scripts/test_docker_networking.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Test that the agent's listener endpoints are reachable from outside the container.
+
+This validates the 0.0.0.0 bind address in the Docker-packaged config by running
+curl from a separate container on the same Docker network.
+"""
+import utils as u
+
+DOCKER_NETWORK = "observe-test-net"
+
+
+def _curl_from_container(remote_host: u.Host, network: str, url: str) -> None:
+    cmd = (
+        f"sudo docker run --rm --network {network} curlimages/curl"
+        f" curl -sf --max-time 5 {url}"
+    )
+    result = remote_host.run_command(cmd)
+    u.print_remote_result(result)
+
+
+@u.print_test_decorator
+def run_test_docker(remote_host: u.Host, env_vars: dict) -> None:
+    container_id = u.get_docker_container(remote_host)
+
+    remote_host.run_command(f"sudo docker network create {DOCKER_NETWORK}")
+    remote_host.run_command(
+        f"sudo docker network connect {DOCKER_NETWORK} {container_id}"
+    )
+    try:
+        print("Testing health check endpoint (port 13133)...")
+        _curl_from_container(
+            remote_host, DOCKER_NETWORK, f"http://{container_id}:13133/status"
+        )
+        print("  ✅ Health check reachable from outside the container")
+
+        print("Testing internal telemetry endpoint (port 8888)...")
+        _curl_from_container(
+            remote_host, DOCKER_NETWORK, f"http://{container_id}:8888/metrics"
+        )
+        print("  ✅ Internal telemetry reachable from outside the container")
+
+        print("Testing OTLP HTTP receiver (port 4318)...")
+        cmd = (
+            f"sudo docker run --rm --network {DOCKER_NETWORK} curlimages/curl"
+            f" curl -sf --max-time 5 -X POST"
+            f" http://{container_id}:4318/v1/traces"
+            f" -H 'Content-Type: application/json'"
+            f" -d '{{\"resourceSpans\":[]}}'"
+        )
+        result = remote_host.run_command(cmd)
+        u.print_remote_result(result)
+        print("  ✅ OTLP HTTP receiver reachable from outside the container")
+
+    finally:
+        remote_host.run_command_unsafe(
+            f"sudo docker network disconnect {DOCKER_NETWORK} {container_id}"
+        )
+        remote_host.run_command_unsafe(f"sudo docker network rm {DOCKER_NETWORK}")
+
+
+if __name__ == "__main__":
+
+    env_vars = u.get_env_vars()
+    remote_host = u.Host(
+        host_ip=env_vars["host"],
+        username=env_vars["user"],
+        key_file_path=env_vars["key_filename"],
+        password=env_vars["password"],
+    )
+
+    remote_host.test_conection(int(env_vars["machine_config"]["sleep"]))
+
+    if "docker" in env_vars["machine_config"]["distribution"]:
+        run_test_docker(remote_host, env_vars)
+    else:
+        print("Skipping: test only applies to docker distribution")

--- a/integration/tests/integration.tftest.hcl
+++ b/integration/tests/integration.tftest.hcl
@@ -196,3 +196,28 @@ run "test_diagnose" {
     error_message = "Error in Diagnose Test"
   }
 }
+
+
+run "test_docker_networking" {
+  module {
+    source  = "observeinc/collection/aws//modules/testing/exec"
+    version = "2.9.0"
+  }
+
+  variables {
+    command = "python3 ./scripts/test_docker_networking.py"
+    env_vars = {
+      HOST           = run.setup_ec2.public_ip
+      USER           = run.setup_ec2.user_name
+      KEY_FILENAME   = run.setup_ec2.private_key_path
+      PASSWORD       = run.setup_ec2.password
+      MACHINE_NAME   = run.setup_ec2.machine_name
+      MACHINE_CONFIG = run.setup_ec2.machine_config
+    }
+  }
+
+  assert {
+    condition     = output.error == ""
+    error_message = "Error in Docker Networking Test"
+  }
+}

--- a/packaging/docker/observe-agent/observe-agent.yaml
+++ b/packaging/docker/observe-agent/observe-agent.yaml
@@ -1,5 +1,17 @@
 # A minimal default agent config which should be overwritten via a docker volume or environment variables.
 debug: false
+
+# Bind to 0.0.0.0 so the agent is reachable from outside the container.
+health_check:
+  endpoint: 0.0.0.0:13133
+forwarding:
+  endpoints:
+    http: 0.0.0.0:4318
+    grpc: 0.0.0.0:4317
+internal_telemetry:
+  metrics:
+    host: 0.0.0.0
+
 self_monitoring:
   enabled: true
 host_monitoring:


### PR DESCRIPTION
## Summary
- The container image defaulted all listener endpoints (OTLP gRPC/HTTP, health check, internal telemetry) to `localhost`, making them unreachable from outside the container.
- Override these addresses to `0.0.0.0` in the docker-packaged `observe-agent.yaml` so other containers, Kubernetes probes, and Prometheus scrapers can connect out of the box.
- No impact on bare-metal Linux, macOS, or Windows installs — their code-level defaults remain `localhost`.
- Add an integration test that spins up a second container on the same Docker network and verifies all three endpoints are reachable from outside the agent container.

## Test plan

- [x] Local Docker test: verified all 3 endpoints reachable with `0.0.0.0`, and unreachable with `localhost` (see results below)
- [x] CI `test_docker_networking` integration test validates health check (13133), internal telemetry (8888), and OTLP HTTP (4318) from a separate container
- [x] Existing snapshot tests unaffected (config-only change, not referenced by tests)

## Local test results

**Image:** `observeinc/observe-agent:latest` (v2.15.0)
**Method:** Start agent in a container, curl endpoints from a separate container on the same Docker network.

### With `0.0.0.0` bindings (the fix)

Config overrides:
```yaml
health_check:
  endpoint: 0.0.0.0:13133
forwarding:
  endpoints:
    http: 0.0.0.0:4318
    grpc: 0.0.0.0:4317
internal_telemetry:
  metrics:
    host: 0.0.0.0
```

Agent logs confirm listeners on all interfaces:
```
Starting GRPC server  {"endpoint": "[::]:4317"}
Starting HTTP server  {"endpoint": "[::]:4318"}
Health Check state change  {"status": "ready"}
Everything is ready. Begin running and processing data.
```

**Test 1: Health Check (port 13133) — PASS**
```
$ docker run --rm --network test-net curlimages/curl curl -sf http://agent:13133/status
{"status":"Server available","upSince":"2026-04-27T04:18:05.415025606Z","uptime":"13.774787092s"}
Exit code: 0
```

**Test 2: Internal Telemetry (port 8888) — PASS**
```
$ docker run --rm --network test-net curlimages/curl curl -sf http://agent:8888/metrics
# HELP otelcol_deltatocumulative_streams_limit upper limit of tracked streams
# TYPE otelcol_deltatocumulative_streams_limit gauge
otelcol_deltatocumulative_streams_limit{...} 9.223372036854776e+18
... (200+ lines of Prometheus metrics)
Exit code: 0
```

**Test 3: OTLP HTTP Receiver (port 4318) — PASS**
```
$ docker run --rm --network test-net curlimages/curl \
    curl -sf -X POST http://agent:4318/v1/traces \
    -H 'Content-Type: application/json' -d '{"resourceSpans":[]}'
{"partialSuccess":{}}
Exit code: 0
```

### With `localhost` defaults (old behavior, no override)

No `health_check`, `forwarding`, or `internal_telemetry` overrides — all default to `localhost`.

**Test 4: Health Check — FAIL (expected)**
```
$ docker run --rm --network test-net curlimages/curl curl -sf --max-time 3 http://agent-old:13133/status
Exit code: 7  (connection refused)
```

**Test 5: Internal Telemetry — FAIL (expected)**
```
$ docker run --rm --network test-net curlimages/curl curl -sf --max-time 3 http://agent-old:8888/metrics
Exit code: 7  (connection refused)
```

**Test 6: OTLP HTTP — FAIL (expected)**
```
$ docker run --rm --network test-net curlimages/curl curl -sf --max-time 3 -X POST http://agent-old:4318/v1/traces ...
Exit code: 7  (connection refused)
```

### Summary

| Endpoint | Port | With `0.0.0.0` | With `localhost` |
|---|---|---|---|
| Health check | 13133 | 200 OK | Connection refused (exit 7) |
| Internal telemetry | 8888 | 200 OK | Connection refused (exit 7) |
| OTLP HTTP receiver | 4318 | 200 OK | Connection refused (exit 7) |