### PR TITLE
fix: default Docker listener endpoints to 0.0.0.0 via Viper defaults

### DIFF
--- a/internal/commands/config/config_test.go
+++ b/internal/commands/config/config_test.go
@@ -203,6 +203,8 @@ func setupConfig(t *testing.T, test snapshotTest) {
 	})
 
 	root.CfgFile = filepath.Join(curPath, test.agentConfigPath)
+	root.RootCmd.PersistentFlags().Set("config-mode", string(test.packageType))
+	t.Cleanup(func() { root.RootCmd.PersistentFlags().Set("config-mode", "") })
 	root.InitConfig()
 
 	setEnvVars(t, test.packageType)

--- a/internal/commands/config/test/snap0-docker-output.yaml
+++ b/internal/commands/config/test/snap0-docker-output.yaml
@@ -54,7 +54,7 @@ extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage
     health_check:
-        endpoint: localhost:13133
+        endpoint: 0.0.0.0:13133
         path: /status
 processors:
     batch:
@@ -212,9 +212,9 @@ receivers:
     otlp:
         protocols:
             grpc:
-                endpoint: localhost:4317
+                endpoint: 0.0.0.0:4317
             http:
-                endpoint: localhost:4318
+                endpoint: 0.0.0.0:4318
     prometheus/agent:
         config:
             scrape_configs:
@@ -227,7 +227,7 @@ receivers:
                   scrape_interval: 10s
                   static_configs:
                     - targets:
-                        - localhost:8888
+                        - 0.0.0.0:8888
 service:
     extensions:
         - health_check
@@ -363,7 +363,7 @@ service:
                 - pull:
                     exporter:
                         prometheus:
-                            host: localhost
+                            host: 0.0.0.0
                             port: 8888
                             with_resource_constant_labels:
                                 included:

--- a/internal/commands/config/test/snap3-docker-output.yaml
+++ b/internal/commands/config/test/snap3-docker-output.yaml
@@ -69,7 +69,7 @@ extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage
     health_check:
-        endpoint: localhost:13133
+        endpoint: 0.0.0.0:13133
         path: /status
 processors:
     batch:
@@ -227,9 +227,9 @@ receivers:
     otlp:
         protocols:
             grpc:
-                endpoint: localhost:4317
+                endpoint: 0.0.0.0:4317
             http:
-                endpoint: localhost:4318
+                endpoint: 0.0.0.0:4318
     prometheus/agent:
         config:
             scrape_configs:
@@ -242,7 +242,7 @@ receivers:
                   scrape_interval: 10s
                   static_configs:
                     - targets:
-                        - localhost:8888
+                        - 0.0.0.0:8888
 service:
     extensions:
         - health_check
@@ -372,7 +372,7 @@ service:
                 - pull:
                     exporter:
                         prometheus:
-                            host: localhost
+                            host: 0.0.0.0
                             port: 8888
                             with_resource_constant_labels:
                                 included:

--- a/internal/commands/initconfig/initconfig_test.go
+++ b/internal/commands/initconfig/initconfig_test.go
@@ -131,7 +131,7 @@ func Test_InitConfigCommand(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		v := viper.NewWithOptions(viper.KeyDelimiter("::"))
-		config.SetViperDefaults(v, "::")
+		config.SetViperDefaults(v, "::", "")
 		initConfigCmd := NewConfigureCmd(v)
 		RegisterConfigFlags(initConfigCmd, v)
 		initConfigCmd.SetArgs(tc.args)

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -150,9 +150,15 @@ func (config *AgentConfig) HasResourceAttributes() bool {
 	return len(config.ResourceAttributes) > 0
 }
 
-func SetViperDefaults(v *viper.Viper, separator string) {
+func SetViperDefaults(v *viper.Viper, separator string, configMode string) {
 	var config AgentConfig
 	defaults.SetDefaults(&config)
+	if strings.ToLower(configMode) == "docker" {
+		config.Forwarding.Endpoints.HTTP = "0.0.0.0:4318"
+		config.Forwarding.Endpoints.GRPC = "0.0.0.0:4317"
+		config.HealthCheck.Endpoint = "0.0.0.0:13133"
+		config.InternalTelemetry.Metrics.Host = "0.0.0.0"
+	}
 	var confMap map[string]any
 	err := mapstructure.Decode(config, &confMap)
 	if err != nil {

--- a/internal/config/configschema_test.go
+++ b/internal/config/configschema_test.go
@@ -134,3 +134,23 @@ func TestAgentConfigFromViper(t *testing.T) {
 	assert.Equal(t, false, config.HealthCheck.Enabled)
 	assert.Equal(t, true, config.Forwarding.Enabled)
 }
+
+func TestSetViperDefaultsDockerConfigMode(t *testing.T) {
+	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
+	SetViperDefaults(v, "::", "docker")
+
+	assert.Equal(t, "0.0.0.0:4318", v.GetString("forwarding::endpoints::http"))
+	assert.Equal(t, "0.0.0.0:4317", v.GetString("forwarding::endpoints::grpc"))
+	assert.Equal(t, "0.0.0.0:13133", v.GetString("health_check::endpoint"))
+	assert.Equal(t, "0.0.0.0", v.GetString("internal_telemetry::metrics::host"))
+}
+
+func TestSetViperDefaultsNonDockerConfigMode(t *testing.T) {
+	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
+	SetViperDefaults(v, "::", "linux")
+
+	assert.Equal(t, "localhost:4318", v.GetString("forwarding::endpoints::http"))
+	assert.Equal(t, "localhost:4317", v.GetString("forwarding::endpoints::grpc"))
+	assert.Equal(t, "localhost:13133", v.GetString("health_check::endpoint"))
+	assert.Equal(t, "localhost", v.GetString("internal_telemetry::metrics::host"))
+}

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -78,6 +78,13 @@ func setConfigMode() {
 
 }
 
+func getConfigMode() string {
+	if configMode != "" {
+		return strings.ToLower(configMode)
+	}
+	return bundledconfig.ConfigEnvironment
+}
+
 // InitConfig reads in config file and ENV variables if set.
 func InitConfig() {
 	setConfigMode()
@@ -99,7 +106,7 @@ func InitConfig() {
 	// viper.SetEnvPrefix("OBSERVE")
 	viper.AutomaticEnv() // read in environment variables that match
 
-	config.SetViperDefaults(viper.GetViper(), "::")
+	config.SetViperDefaults(viper.GetViper(), "::", getConfigMode())
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {

--- a/packaging/docker/observe-agent/observe-agent.yaml
+++ b/packaging/docker/observe-agent/observe-agent.yaml
@@ -1,17 +1,5 @@
 # A minimal default agent config which should be overwritten via a docker volume or environment variables.
 debug: false
-
-# Bind to 0.0.0.0 so the agent is reachable from outside the container.
-health_check:
-  endpoint: 0.0.0.0:13133
-forwarding:
-  endpoints:
-    http: 0.0.0.0:4318
-    grpc: 0.0.0.0:4317
-internal_telemetry:
-  metrics:
-    host: 0.0.0.0
-
 self_monitoring:
   enabled: true
 host_monitoring:


### PR DESCRIPTION
## Summary
- Follow-up to #328 (79238b8). The previous fix updated the packaged `observe-agent.yaml` to bind listeners to `0.0.0.0` in Docker, but customers who supply their own config file still fell back to the hardcoded `localhost` defaults, making the agent unreachable from outside the container.
- Add `setDockerDefaults()` in `root.go` that overrides Viper defaults for forwarding gRPC/HTTP, health check, and internal telemetry endpoints to `0.0.0.0` when `--config-mode=docker`. This ensures the agent binds to all interfaces even when a custom `observe-agent.yaml` omits these settings.
- Remove the now-redundant `0.0.0.0` overrides from the packaged `packaging/docker/observe-agent/observe-agent.yaml` since the Viper defaults handle this.
- Customer-provided values in the config file still take precedence over these defaults.

## Test plan
- [x] Updated snapshot tests to set `config-mode` flag for each package type, matching production behavior
- [x] Docker snapshots (`snap0-docker-output.yaml`, `snap3-docker-output.yaml`) updated to expect `0.0.0.0` endpoints
- [x] `snap1-docker-output.yaml` (full config with explicit endpoints) unaffected — confirms customer overrides still work
- [x] All Linux/macOS/Windows snapshots unchanged — confirms no impact on non-Docker modes
- [x] All 14 snapshot tests pass

## Local Docker test results

**Setup:** Built the Docker image with the reverted `observe-agent.yaml` (no `0.0.0.0` overrides in the config file). Started the agent with `--config-mode docker` and tested from a separate container on the same Docker network.

Agent logs confirm listeners on all interfaces (from `setDockerDefaults()` Viper defaults only):
```
Starting GRPC server  {"endpoint": "[::]:4317"}
Starting HTTP server  {"endpoint": "[::]:4318"}
Health Check state change  {"status": "ready"}
Everything is ready. Begin running and processing data.
```

**Test 1: Health Check (port 13133) — PASS**
```
$ docker run --rm --network test-net curlimages/curl curl -sf http://agent-test:13133/status
{"status":"Server available","upSince":"2026-04-27T20:03:41.629448741Z","uptime":"2m46.892990843s"}
Exit code: 0
```

**Test 2: Internal Telemetry (port 8888) — PASS**
```
$ docker run --rm --network test-net curlimages/curl curl -sf http://agent-test:8888/metrics
# HELP http_client_request_body_size_bytes Size of HTTP client request bodies.
# TYPE http_client_request_body_size_bytes histogram
... (200+ lines of Prometheus metrics)
Exit code: 0
```

**Test 3: OTLP HTTP Receiver (port 4318) — PASS**
```
$ docker run --rm --network test-net curlimages/curl \
    curl -sf -X POST http://agent-test:4318/v1/traces \
    -H 'Content-Type: application/json' -d '{"resourceSpans":[]}'
{"partialSuccess":{}}
Exit code: 0
```

| Endpoint | Port | Result |
|---|---|---|
| Health check | 13133 | 200 OK |
| Internal telemetry | 8888 | 200 OK |
| OTLP HTTP receiver | 4318 | 200 OK |