### PR TITLE
feat: update RED metrics generation to include summary metrics for improved APM query performance

### DIFF
--- a/internal/commands/config/config_test.go
+++ b/internal/commands/config/config_test.go
@@ -116,6 +116,27 @@ var allSnapshotTests = []snapshotTest{
 		outputPath:      "test/snap3-windows-output.yaml",
 		packageType:     Windows,
 	},
+	// Tests with the recommended connection-portal settings
+	{
+		agentConfigPath: "test/snap4-recommended-settings-agent-config.yaml",
+		outputPath:      "test/snap4-docker-output.yaml",
+		packageType:     Docker,
+	},
+	{
+		agentConfigPath: "test/snap4-recommended-settings-agent-config.yaml",
+		outputPath:      "test/snap4-linux-output.yaml",
+		packageType:     Linux,
+	},
+	{
+		agentConfigPath: "test/snap4-recommended-settings-agent-config.yaml",
+		outputPath:      "test/snap4-macos-output.yaml",
+		packageType:     MacOS,
+	},
+	{
+		agentConfigPath: "test/snap4-recommended-settings-agent-config.yaml",
+		outputPath:      "test/snap4-windows-output.yaml",
+		packageType:     Windows,
+	},
 }
 
 // This test cannot be run in our CI since some of the OTel components validate file paths

--- a/internal/commands/config/test/snap0-linux-output.yaml
+++ b/internal/commands/config/test/snap0-linux-output.yaml
@@ -68,17 +68,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -123,6 +112,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -346,7 +344,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp

--- a/internal/commands/config/test/snap0-macos-output.yaml
+++ b/internal/commands/config/test/snap0-macos-output.yaml
@@ -68,17 +68,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -123,6 +112,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -308,7 +306,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp

--- a/internal/commands/config/test/snap0-windows-output.yaml
+++ b/internal/commands/config/test/snap0-windows-output.yaml
@@ -68,17 +68,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -102,6 +91,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -301,7 +299,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp

--- a/internal/commands/config/test/snap1-docker-output.yaml
+++ b/internal/commands/config/test/snap1-docker-output.yaml
@@ -1,5 +1,22 @@
 connectors:
     count: null
+    forward/red_metrics_summary: null
+    routing/red_metrics_internal:
+        default_pipelines:
+            - metrics/spanmetrics/default
+        error_mode: ignore
+        table:
+            - context: datapoint
+              pipelines:
+                - metrics/spanmetrics/internal
+              statement: |
+                route() where
+                  attributes["span.kind"] == "SPAN_KIND_INTERNAL"
+                  or attributes["span.kind"] == "SPAN_KIND_UNSPECIFIED"
+                  or (attributes["span.kind"] == "SPAN_KIND_CLIENT"
+                      and attributes["peer.db.name"] == nil)
+                  or (attributes["span.kind"] == "SPAN_KIND_PRODUCER"
+                      and attributes["peer.messaging.system"] == nil)
     spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
         dimensions:
@@ -15,6 +32,29 @@ connectors:
         histogram:
             exponential:
                 max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - team.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
@@ -114,14 +154,14 @@ processors:
         traces:
             span:
                 - (span.end_time - span.start_time) > Duration("30m")
-    filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+    filter/drop_non_apm_spans:
         error_mode: ignore
         traces:
             span:
-                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
                 - span.kind == SPAN_KIND_UNSPECIFIED
                 - span.kind == SPAN_KIND_INTERNAL
-                - span.kind == SPAN_KIND_PRODUCER
     groupbyattrs/peers:
         keys:
             - peer.db.name
@@ -130,17 +170,22 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
+    metricstransform/rename_internal_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.internal
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.internal
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -202,6 +247,15 @@ processors:
             - system
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -210,16 +264,19 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
-    transform/fix_peer_attributes:
-        error_mode: ignore
-        metric_statements:
-            - set(datapoint.attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
-            - set(datapoint.attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
     transform/fix_red_metrics_resource_attributes:
         error_mode: ignore
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
             - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
             - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
@@ -231,6 +288,21 @@ processors:
                 - set(attributes["observe_transform"]["identifiers"]["deployment.environment.name"], resource.attributes["deployment.environment.name"])
                 - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
                 - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
         metric_statements:
@@ -240,7 +312,7 @@ processors:
         trace_statements:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
-            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
             - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
@@ -537,20 +609,44 @@ service:
                 - hostmetrics/host-monitoring-process
         metrics/spanmetrics:
             exporters:
-                - otlphttp/observemetrics
+                - routing/red_metrics_internal
             processors:
                 - memory_limiter
-                - groupbyattrs/peers
-                - transform/fix_peer_attributes
                 - transform/remove_service_name_for_peer_metrics
                 - transform/fix_red_metrics_resource_attributes
-                - resourcedetection
-                - resourcedetection/cloud
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - spanmetrics
+        metrics/spanmetrics/default:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/internal:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - metricstransform/rename_internal_metrics
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
@@ -563,22 +659,34 @@ service:
                 - transform/add_span_status_code
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp
         traces/spanmetrics:
             exporters:
                 - spanmetrics
+                - forward/red_metrics_summary
             processors:
                 - memory_limiter
                 - filter/drop_long_spans
-                - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+                - resourcedetection
+                - resourcedetection/cloud
                 - transform/shape_spans_for_red_metrics
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
+        traces/spanmetrics/summary/filter:
+            exporters:
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_non_apm_spans
+            receivers:
+                - forward/red_metrics_summary
     telemetry:
         logs:
             encoding: json

--- a/internal/commands/config/test/snap1-full-agent-config.yaml
+++ b/internal/commands/config/test/snap1-full-agent-config.yaml
@@ -75,7 +75,7 @@ self_monitoring:
 application:
     RED_metrics:
         enabled: true
-        only_generate_for_service_entrypoint_spans: true
+        only_generate_for_apm_spans: false
         resource_dimensions:
             - service.name
             - service.namespace

--- a/internal/commands/config/test/snap1-linux-output.yaml
+++ b/internal/commands/config/test/snap1-linux-output.yaml
@@ -1,5 +1,22 @@
 connectors:
     count: null
+    forward/red_metrics_summary: null
+    routing/red_metrics_internal:
+        default_pipelines:
+            - metrics/spanmetrics/default
+        error_mode: ignore
+        table:
+            - context: datapoint
+              pipelines:
+                - metrics/spanmetrics/internal
+              statement: |
+                route() where
+                  attributes["span.kind"] == "SPAN_KIND_INTERNAL"
+                  or attributes["span.kind"] == "SPAN_KIND_UNSPECIFIED"
+                  or (attributes["span.kind"] == "SPAN_KIND_CLIENT"
+                      and attributes["peer.db.name"] == nil)
+                  or (attributes["span.kind"] == "SPAN_KIND_PRODUCER"
+                      and attributes["peer.messaging.system"] == nil)
     spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
         dimensions:
@@ -15,6 +32,29 @@ connectors:
         histogram:
             exponential:
                 max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - team.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
@@ -111,14 +151,14 @@ processors:
         traces:
             span:
                 - (span.end_time - span.start_time) > Duration("30m")
-    filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+    filter/drop_non_apm_spans:
         error_mode: ignore
         traces:
             span:
-                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
                 - span.kind == SPAN_KIND_UNSPECIFIED
                 - span.kind == SPAN_KIND_INTERNAL
-                - span.kind == SPAN_KIND_PRODUCER
     groupbyattrs/peers:
         keys:
             - peer.db.name
@@ -127,17 +167,22 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
+    metricstransform/rename_internal_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.internal
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.internal
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -199,6 +244,15 @@ processors:
             - system
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -207,16 +261,19 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
-    transform/fix_peer_attributes:
-        error_mode: ignore
-        metric_statements:
-            - set(datapoint.attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
-            - set(datapoint.attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
     transform/fix_red_metrics_resource_attributes:
         error_mode: ignore
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
             - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
             - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
@@ -228,6 +285,21 @@ processors:
                 - set(attributes["observe_transform"]["identifiers"]["deployment.environment.name"], resource.attributes["deployment.environment.name"])
                 - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
                 - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
         metric_statements:
@@ -237,7 +309,7 @@ processors:
         trace_statements:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
-            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
             - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
@@ -531,20 +603,44 @@ service:
                 - hostmetrics/host-monitoring-process
         metrics/spanmetrics:
             exporters:
-                - otlphttp/observemetrics
+                - routing/red_metrics_internal
             processors:
                 - memory_limiter
-                - groupbyattrs/peers
-                - transform/fix_peer_attributes
                 - transform/remove_service_name_for_peer_metrics
                 - transform/fix_red_metrics_resource_attributes
-                - resourcedetection
-                - resourcedetection/cloud
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - spanmetrics
+        metrics/spanmetrics/default:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/internal:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - metricstransform/rename_internal_metrics
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
@@ -557,22 +653,34 @@ service:
                 - transform/add_span_status_code
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp
         traces/spanmetrics:
             exporters:
                 - spanmetrics
+                - forward/red_metrics_summary
             processors:
                 - memory_limiter
                 - filter/drop_long_spans
-                - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+                - resourcedetection
+                - resourcedetection/cloud
                 - transform/shape_spans_for_red_metrics
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
+        traces/spanmetrics/summary/filter:
+            exporters:
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_non_apm_spans
+            receivers:
+                - forward/red_metrics_summary
     telemetry:
         logs:
             encoding: json

--- a/internal/commands/config/test/snap1-macos-output.yaml
+++ b/internal/commands/config/test/snap1-macos-output.yaml
@@ -1,5 +1,22 @@
 connectors:
     count: null
+    forward/red_metrics_summary: null
+    routing/red_metrics_internal:
+        default_pipelines:
+            - metrics/spanmetrics/default
+        error_mode: ignore
+        table:
+            - context: datapoint
+              pipelines:
+                - metrics/spanmetrics/internal
+              statement: |
+                route() where
+                  attributes["span.kind"] == "SPAN_KIND_INTERNAL"
+                  or attributes["span.kind"] == "SPAN_KIND_UNSPECIFIED"
+                  or (attributes["span.kind"] == "SPAN_KIND_CLIENT"
+                      and attributes["peer.db.name"] == nil)
+                  or (attributes["span.kind"] == "SPAN_KIND_PRODUCER"
+                      and attributes["peer.messaging.system"] == nil)
     spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
         dimensions:
@@ -15,6 +32,29 @@ connectors:
         histogram:
             exponential:
                 max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - team.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
@@ -111,14 +151,14 @@ processors:
         traces:
             span:
                 - (span.end_time - span.start_time) > Duration("30m")
-    filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+    filter/drop_non_apm_spans:
         error_mode: ignore
         traces:
             span:
-                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
                 - span.kind == SPAN_KIND_UNSPECIFIED
                 - span.kind == SPAN_KIND_INTERNAL
-                - span.kind == SPAN_KIND_PRODUCER
     groupbyattrs/peers:
         keys:
             - peer.db.name
@@ -127,17 +167,22 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
+    metricstransform/rename_internal_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.internal
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.internal
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -199,6 +244,15 @@ processors:
             - system
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -207,16 +261,19 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
-    transform/fix_peer_attributes:
-        error_mode: ignore
-        metric_statements:
-            - set(datapoint.attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
-            - set(datapoint.attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
     transform/fix_red_metrics_resource_attributes:
         error_mode: ignore
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
             - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
             - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
@@ -228,6 +285,21 @@ processors:
                 - set(attributes["observe_transform"]["identifiers"]["deployment.environment.name"], resource.attributes["deployment.environment.name"])
                 - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
                 - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
         metric_statements:
@@ -237,7 +309,7 @@ processors:
         trace_statements:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
-            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
             - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
@@ -489,20 +561,44 @@ service:
                 - hostmetrics/host-monitoring-process
         metrics/spanmetrics:
             exporters:
-                - otlphttp/observemetrics
+                - routing/red_metrics_internal
             processors:
                 - memory_limiter
-                - groupbyattrs/peers
-                - transform/fix_peer_attributes
                 - transform/remove_service_name_for_peer_metrics
                 - transform/fix_red_metrics_resource_attributes
-                - resourcedetection
-                - resourcedetection/cloud
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - spanmetrics
+        metrics/spanmetrics/default:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/internal:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - metricstransform/rename_internal_metrics
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
@@ -515,22 +611,34 @@ service:
                 - transform/add_span_status_code
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp
         traces/spanmetrics:
             exporters:
                 - spanmetrics
+                - forward/red_metrics_summary
             processors:
                 - memory_limiter
                 - filter/drop_long_spans
-                - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+                - resourcedetection
+                - resourcedetection/cloud
                 - transform/shape_spans_for_red_metrics
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
+        traces/spanmetrics/summary/filter:
+            exporters:
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_non_apm_spans
+            receivers:
+                - forward/red_metrics_summary
     telemetry:
         logs:
             encoding: json

--- a/internal/commands/config/test/snap1-windows-output.yaml
+++ b/internal/commands/config/test/snap1-windows-output.yaml
@@ -1,5 +1,22 @@
 connectors:
     count: null
+    forward/red_metrics_summary: null
+    routing/red_metrics_internal:
+        default_pipelines:
+            - metrics/spanmetrics/default
+        error_mode: ignore
+        table:
+            - context: datapoint
+              pipelines:
+                - metrics/spanmetrics/internal
+              statement: |
+                route() where
+                  attributes["span.kind"] == "SPAN_KIND_INTERNAL"
+                  or attributes["span.kind"] == "SPAN_KIND_UNSPECIFIED"
+                  or (attributes["span.kind"] == "SPAN_KIND_CLIENT"
+                      and attributes["peer.db.name"] == nil)
+                  or (attributes["span.kind"] == "SPAN_KIND_PRODUCER"
+                      and attributes["peer.messaging.system"] == nil)
     spanmetrics:
         aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
         dimensions:
@@ -15,6 +32,29 @@ connectors:
         histogram:
             exponential:
                 max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - team.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
@@ -111,14 +151,14 @@ processors:
         traces:
             span:
                 - (span.end_time - span.start_time) > Duration("30m")
-    filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+    filter/drop_non_apm_spans:
         error_mode: ignore
         traces:
             span:
-                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
                 - span.kind == SPAN_KIND_UNSPECIFIED
                 - span.kind == SPAN_KIND_INTERNAL
-                - span.kind == SPAN_KIND_PRODUCER
     groupbyattrs/peers:
         keys:
             - peer.db.name
@@ -127,17 +167,22 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
+    metricstransform/rename_internal_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.internal
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.internal
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -178,6 +223,15 @@ processors:
             - system
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -186,16 +240,19 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
-    transform/fix_peer_attributes:
-        error_mode: ignore
-        metric_statements:
-            - set(datapoint.attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
-            - set(datapoint.attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
     transform/fix_red_metrics_resource_attributes:
         error_mode: ignore
         metric_statements:
             - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
             - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|team.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
             - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
             - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
             - delete_key(datapoint.attributes, "status.code")
@@ -207,6 +264,21 @@ processors:
                 - set(attributes["observe_transform"]["identifiers"]["deployment.environment.name"], resource.attributes["deployment.environment.name"])
                 - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
                 - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
     transform/remove_service_name_for_peer_metrics:
         error_mode: ignore
         metric_statements:
@@ -216,7 +288,7 @@ processors:
         trace_statements:
             - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
             - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
-            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
             - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
@@ -510,20 +582,44 @@ service:
                 - hostmetrics/host-monitoring-process
         metrics/spanmetrics:
             exporters:
-                - otlphttp/observemetrics
+                - routing/red_metrics_internal
             processors:
                 - memory_limiter
-                - groupbyattrs/peers
-                - transform/fix_peer_attributes
                 - transform/remove_service_name_for_peer_metrics
                 - transform/fix_red_metrics_resource_attributes
-                - resourcedetection
-                - resourcedetection/cloud
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
                 - batch
             receivers:
                 - spanmetrics
+        metrics/spanmetrics/default:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/internal:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - metricstransform/rename_internal_metrics
+            receivers:
+                - routing/red_metrics_internal
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - attributes/observe_global_attributes
+                - resource/observe_global_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
@@ -536,22 +632,34 @@ service:
                 - transform/add_span_status_code
                 - attributes/observe_global_attributes
                 - resource/observe_global_resource_attributes
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
                 - batch
             receivers:
                 - otlp
         traces/spanmetrics:
             exporters:
                 - spanmetrics
+                - forward/red_metrics_summary
             processors:
                 - memory_limiter
                 - filter/drop_long_spans
-                - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+                - resourcedetection
+                - resourcedetection/cloud
                 - transform/shape_spans_for_red_metrics
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
+        traces/spanmetrics/summary/filter:
+            exporters:
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_non_apm_spans
+            receivers:
+                - forward/red_metrics_summary
     telemetry:
         logs:
             encoding: json

--- a/internal/commands/config/test/snap3-docker-output.yaml
+++ b/internal/commands/config/test/snap3-docker-output.yaml
@@ -86,17 +86,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -141,6 +130,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -361,7 +359,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:

--- a/internal/commands/config/test/snap3-linux-output.yaml
+++ b/internal/commands/config/test/snap3-linux-output.yaml
@@ -83,17 +83,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -138,6 +127,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -356,7 +354,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:

--- a/internal/commands/config/test/snap3-macos-output.yaml
+++ b/internal/commands/config/test/snap3-macos-output.yaml
@@ -83,17 +83,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -138,6 +127,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -320,7 +318,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:

--- a/internal/commands/config/test/snap3-windows-output.yaml
+++ b/internal/commands/config/test/snap3-windows-output.yaml
@@ -83,17 +83,6 @@ processors:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
-    resource/add_empty_service_attributes:
-        attributes:
-            - action: insert
-              key: service.name
-              value: ""
-            - action: insert
-              key: service.namespace
-              value: ""
-            - action: insert
-              key: deployment.environment
-              value: ""
     resource/agent_instance:
         attributes:
             - action: upsert
@@ -117,6 +106,15 @@ processors:
             - azure
         override: false
         timeout: 2s
+    transform/add_empty_service_attributes:
+        error_mode: ignore
+        trace_statements:
+            - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+            - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+            - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+            - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+            - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+            - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
     transform/add_span_status_code:
         error_mode: ignore
         trace_statements:
@@ -312,7 +310,7 @@ service:
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
-                - resource/add_empty_service_attributes
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:

--- a/internal/commands/config/test/snap4-docker-output.yaml
+++ b/internal/commands/config/test/snap4-docker-output.yaml
@@ -1,8 +1,61 @@
 connectors:
     count: null
+    spanmetrics:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: host.name
+            - name: container.id
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: otel.status_description
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - host.name
+            - container.id
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
+    otlphttp/agentheartbeat:
+        compression: zstd
+        headers:
+            Authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            X-Observe-Agent-Instance-Id: test-agent-instance-id
+            X-Observe-Context: '{"environment":"docker","version":"dev"}'
+            X-Observe-Enable-Auth-Error-Reporting: "true"
+            X-Observe-Target-Package: Observe Agent
+        logs_endpoint: https://123456789.collect.observe-eng.com/v1/kubernetes/v1/entity
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
     otlphttp/observe:
         compression: zstd
         endpoint: https://123456789.collect.observe-eng.com/v2/otel
@@ -67,15 +120,45 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    filter/drop_long_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - (span.end_time - span.start_time) > Duration("1h")
+    filter/drop_non_apm_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
+                - span.kind == SPAN_KIND_UNSPECIFIED
+                - span.kind == SPAN_KIND_INTERNAL
+    groupbyattrs/peers:
+        keys:
+            - peer.db.name
+            - peer.messaging.system
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
               key: observe.agent.instance.id
               value: test-agent-instance-id
+    resource/heartbeat:
+        attributes:
+            - action: insert
+              from_attribute: host.name
+              key: observe.agent.hostname
     resourcedetection:
         detectors:
             - env
@@ -132,6 +215,55 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
+    transform/fix_red_metrics_resource_attributes:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name|container.id)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name|container.id)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/heartbeat:
+        error_mode: ignore
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
+                - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
+    transform/remove_service_name_for_peer_metrics:
+        error_mode: ignore
+        metric_statements:
+            - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+    transform/shape_spans_for_red_metrics:
+        error_mode: ignore
+        trace_statements:
+            - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
+            - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log
@@ -160,6 +292,14 @@ receivers:
         collection_interval: 5m
         include: /etc/observe-agent/observe-agent.yaml
         initial_delay: 60s
+    heartbeat:
+        auth_check:
+            headers:
+                authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            url: https://123456789.collect.observe-eng.com
+        config_interval: 24h
+        environment: docker
+        interval: 10m
     hostmetrics/host-monitoring-host:
         collection_interval: 60s
         root_path: /hostfs
@@ -248,6 +388,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - batch
             receivers:
                 - journald/agent
@@ -263,6 +404,17 @@ service:
                 - batch
             receivers:
                 - otlp
+        logs/heartbeat:
+            exporters:
+                - otlphttp/agentheartbeat
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - resource/agent_instance
+                - resource/heartbeat
+                - transform/heartbeat
+            receivers:
+                - heartbeat
         logs/host_monitoring-file:
             exporters:
                 - otlphttp/observe
@@ -305,6 +457,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - deltatocumulative
                 - batch
             receivers:
@@ -340,17 +493,56 @@ service:
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
+        metrics/spanmetrics:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
             processors:
                 - memory_limiter
+                - filter/drop_long_spans
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
                 - transform/add_empty_service_attributes
                 - batch
+            receivers:
+                - otlp
+        traces/spanmetrics:
+            exporters:
+                - spanmetrics
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_long_spans
+                - filter/drop_non_apm_spans
+                - resourcedetection
+                - resourcedetection/cloud
+                - transform/shape_spans_for_red_metrics
+                - transform/add_span_status_code
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:

--- a/internal/commands/config/test/snap4-linux-output.yaml
+++ b/internal/commands/config/test/snap4-linux-output.yaml
@@ -1,8 +1,59 @@
 connectors:
     count: null
+    spanmetrics:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: host.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: otel.status_description
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - host.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
+    otlphttp/agentheartbeat:
+        compression: zstd
+        headers:
+            Authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            X-Observe-Agent-Instance-Id: test-agent-instance-id
+            X-Observe-Context: '{"environment":"linux","version":"dev"}'
+            X-Observe-Enable-Auth-Error-Reporting: "true"
+            X-Observe-Target-Package: Observe Agent
+        logs_endpoint: https://123456789.collect.observe-eng.com/v1/kubernetes/v1/entity
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
     otlphttp/observe:
         compression: zstd
         endpoint: https://123456789.collect.observe-eng.com/v2/otel
@@ -50,13 +101,10 @@ exporters:
         target_info:
             enabled: false
 extensions:
-    cgroupruntime:
-        gomaxprocs:
-            enabled: true
     file_storage:
         directory: /var/lib/observe-agent/filestorage
     health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: localhost:13133
         path: /status
 processors:
     batch:
@@ -67,15 +115,45 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    filter/drop_long_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - (span.end_time - span.start_time) > Duration("1h")
+    filter/drop_non_apm_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
+                - span.kind == SPAN_KIND_UNSPECIFIED
+                - span.kind == SPAN_KIND_INTERNAL
+    groupbyattrs/peers:
+        keys:
+            - peer.db.name
+            - peer.messaging.system
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
               key: observe.agent.instance.id
               value: test-agent-instance-id
+    resource/heartbeat:
+        attributes:
+            - action: insert
+              from_attribute: host.name
+              key: observe.agent.hostname
     resourcedetection:
         detectors:
             - env
@@ -132,6 +210,55 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
+    transform/fix_red_metrics_resource_attributes:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/heartbeat:
+        error_mode: ignore
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
+                - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
+    transform/remove_service_name_for_peer_metrics:
+        error_mode: ignore
+        metric_statements:
+            - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+    transform/shape_spans_for_red_metrics:
+        error_mode: ignore
+        trace_statements:
+            - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
+            - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log
@@ -146,8 +273,8 @@ processors:
 receivers:
     filelog/host_monitoring:
         include:
-            - /hostfs/var/log/**/*.log
-            - /hostfs/var/log/syslog
+            - /var/log/**/*.log
+            - /var/log/syslog
         include_file_path: true
         max_log_size: 4MiB
         operators:
@@ -160,9 +287,16 @@ receivers:
         collection_interval: 5m
         include: /etc/observe-agent/observe-agent.yaml
         initial_delay: 60s
+    heartbeat:
+        auth_check:
+            headers:
+                authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            url: https://123456789.collect.observe-eng.com
+        config_interval: 24h
+        environment: linux
+        interval: 10m
     hostmetrics/host-monitoring-host:
         collection_interval: 60s
-        root_path: /hostfs
         scrapers:
             cpu:
                 metrics:
@@ -212,9 +346,9 @@ receivers:
     otlp:
         protocols:
             grpc:
-                endpoint: 0.0.0.0:4317
+                endpoint: localhost:4317
             http:
-                endpoint: 0.0.0.0:4318
+                endpoint: localhost:4318
     prometheus/agent:
         config:
             scrape_configs:
@@ -227,12 +361,11 @@ receivers:
                   scrape_interval: 10s
                   static_configs:
                     - targets:
-                        - 0.0.0.0:8888
+                        - localhost:8888
 service:
     extensions:
         - health_check
         - file_storage
-        - cgroupruntime
     pipelines:
         logs/agent-config:
             exporters:
@@ -248,6 +381,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - batch
             receivers:
                 - journald/agent
@@ -263,6 +397,17 @@ service:
                 - batch
             receivers:
                 - otlp
+        logs/heartbeat:
+            exporters:
+                - otlphttp/agentheartbeat
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - resource/agent_instance
+                - resource/heartbeat
+                - transform/heartbeat
+            receivers:
+                - heartbeat
         logs/host_monitoring-file:
             exporters:
                 - otlphttp/observe
@@ -305,6 +450,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - deltatocumulative
                 - batch
             receivers:
@@ -340,17 +486,56 @@ service:
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
+        metrics/spanmetrics:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
             processors:
                 - memory_limiter
+                - filter/drop_long_spans
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
                 - transform/add_empty_service_attributes
                 - batch
+            receivers:
+                - otlp
+        traces/spanmetrics:
+            exporters:
+                - spanmetrics
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_long_spans
+                - filter/drop_non_apm_spans
+                - resourcedetection
+                - resourcedetection/cloud
+                - transform/shape_spans_for_red_metrics
+                - transform/add_span_status_code
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:
@@ -363,7 +548,7 @@ service:
                 - pull:
                     exporter:
                         prometheus:
-                            host: 0.0.0.0
+                            host: localhost
                             port: 8888
                             with_resource_constant_labels:
                                 included:

--- a/internal/commands/config/test/snap4-macos-output.yaml
+++ b/internal/commands/config/test/snap4-macos-output.yaml
@@ -1,8 +1,59 @@
 connectors:
     count: null
+    spanmetrics:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: host.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: otel.status_description
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - host.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
+    otlphttp/agentheartbeat:
+        compression: zstd
+        headers:
+            Authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            X-Observe-Agent-Instance-Id: test-agent-instance-id
+            X-Observe-Context: '{"environment":"macos","version":"dev"}'
+            X-Observe-Enable-Auth-Error-Reporting: "true"
+            X-Observe-Target-Package: Observe Agent
+        logs_endpoint: https://123456789.collect.observe-eng.com/v1/kubernetes/v1/entity
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
     otlphttp/observe:
         compression: zstd
         endpoint: https://123456789.collect.observe-eng.com/v2/otel
@@ -50,13 +101,10 @@ exporters:
         target_info:
             enabled: false
 extensions:
-    cgroupruntime:
-        gomaxprocs:
-            enabled: true
     file_storage:
         directory: /var/lib/observe-agent/filestorage
     health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: localhost:13133
         path: /status
 processors:
     batch:
@@ -67,15 +115,45 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    filter/drop_long_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - (span.end_time - span.start_time) > Duration("1h")
+    filter/drop_non_apm_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
+                - span.kind == SPAN_KIND_UNSPECIFIED
+                - span.kind == SPAN_KIND_INTERNAL
+    groupbyattrs/peers:
+        keys:
+            - peer.db.name
+            - peer.messaging.system
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
               key: observe.agent.instance.id
               value: test-agent-instance-id
+    resource/heartbeat:
+        attributes:
+            - action: insert
+              from_attribute: host.name
+              key: observe.agent.hostname
     resourcedetection:
         detectors:
             - env
@@ -132,6 +210,55 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
+    transform/fix_red_metrics_resource_attributes:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/heartbeat:
+        error_mode: ignore
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
+                - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
+    transform/remove_service_name_for_peer_metrics:
+        error_mode: ignore
+        metric_statements:
+            - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+    transform/shape_spans_for_red_metrics:
+        error_mode: ignore
+        trace_statements:
+            - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
+            - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log
@@ -146,8 +273,7 @@ processors:
 receivers:
     filelog/host_monitoring:
         include:
-            - /hostfs/var/log/**/*.log
-            - /hostfs/var/log/syslog
+            - /var/log/**/*.log
         include_file_path: true
         max_log_size: 4MiB
         operators:
@@ -158,11 +284,18 @@ receivers:
         storage: file_storage
     filestats/agent:
         collection_interval: 5m
-        include: /etc/observe-agent/observe-agent.yaml
+        include: /usr/local/observe-agent/observe-agent.yaml
         initial_delay: 60s
+    heartbeat:
+        auth_check:
+            headers:
+                authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            url: https://123456789.collect.observe-eng.com
+        config_interval: 24h
+        environment: macos
+        interval: 10m
     hostmetrics/host-monitoring-host:
         collection_interval: 60s
-        root_path: /hostfs
         scrapers:
             cpu:
                 metrics:
@@ -182,39 +315,26 @@ receivers:
             load: null
             memory:
                 metrics:
-                    system.linux.memory.available:
-                        enabled: true
                     system.memory.utilization:
                         enabled: true
-            network: null
+            network:
+                metrics:
+                    system.network.conntrack.count:
+                        enabled: true
+                    system.network.conntrack.max:
+                        enabled: true
             paging:
                 metrics:
                     system.paging.utilization:
                         enabled: true
             processes: null
-    journald/agent:
-        priority: info
-        units:
-            - observe-agent
-    journald/host_monitoring:
-        priority: info
-        units:
-            - cron
-            - ssh
-            - systemd-networkd
-            - systemd-resolved
-            - systemd-login
-            - multipathd
-            - systemd-user-sessions
-            - ufw
-            - observe-agent
     nop: null
     otlp:
         protocols:
             grpc:
-                endpoint: 0.0.0.0:4317
+                endpoint: localhost:4317
             http:
-                endpoint: 0.0.0.0:4318
+                endpoint: localhost:4318
     prometheus/agent:
         config:
             scrape_configs:
@@ -227,30 +347,17 @@ receivers:
                   scrape_interval: 10s
                   static_configs:
                     - targets:
-                        - 0.0.0.0:8888
+                        - localhost:8888
 service:
     extensions:
         - health_check
         - file_storage
-        - cgroupruntime
     pipelines:
         logs/agent-config:
             exporters:
                 - nop
             receivers:
                 - nop
-        logs/agent-journald:
-            exporters:
-                - otlphttp/observe
-                - count
-            processors:
-                - memory_limiter
-                - transform/truncate
-                - resourcedetection
-                - resourcedetection/cloud
-                - batch
-            receivers:
-                - journald/agent
         logs/forward:
             exporters:
                 - otlphttp/observe
@@ -263,6 +370,17 @@ service:
                 - batch
             receivers:
                 - otlp
+        logs/heartbeat:
+            exporters:
+                - otlphttp/agentheartbeat
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - resource/agent_instance
+                - resource/heartbeat
+                - transform/heartbeat
+            receivers:
+                - heartbeat
         logs/host_monitoring-file:
             exporters:
                 - otlphttp/observe
@@ -275,18 +393,6 @@ service:
                 - batch
             receivers:
                 - filelog/host_monitoring
-        logs/host_monitoring-journald:
-            exporters:
-                - otlphttp/observe
-                - count
-            processors:
-                - memory_limiter
-                - transform/truncate
-                - resourcedetection
-                - resourcedetection/cloud
-                - batch
-            receivers:
-                - journald/host_monitoring
         metrics/agent-filestats:
             exporters:
                 - prometheusremotewrite/observe
@@ -305,6 +411,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - deltatocumulative
                 - batch
             receivers:
@@ -340,17 +447,56 @@ service:
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
+        metrics/spanmetrics:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
             processors:
                 - memory_limiter
+                - filter/drop_long_spans
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
                 - transform/add_empty_service_attributes
                 - batch
+            receivers:
+                - otlp
+        traces/spanmetrics:
+            exporters:
+                - spanmetrics
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_long_spans
+                - filter/drop_non_apm_spans
+                - resourcedetection
+                - resourcedetection/cloud
+                - transform/shape_spans_for_red_metrics
+                - transform/add_span_status_code
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:
@@ -363,7 +509,7 @@ service:
                 - pull:
                     exporter:
                         prometheus:
-                            host: 0.0.0.0
+                            host: localhost
                             port: 8888
                             with_resource_constant_labels:
                                 included:

--- a/internal/commands/config/test/snap4-recommended-settings-agent-config.yaml
+++ b/internal/commands/config/test/snap4-recommended-settings-agent-config.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../../../../observe-agent.schema.json
+# Target Observe collection url
+observe_url: https://123456789.collect.observe-eng.com/
+
+# Observe data token
+token: abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+
+forwarding:
+    metrics:
+        output_format: otel
+
+application:
+    RED_metrics:
+        enabled: true
+        only_generate_for_apm_spans: true
+
+self_monitoring:
+    enabled: true
+    fleet:
+        enabled: true
+
+host_monitoring:
+    enabled: true
+    logs:
+        enabled: true
+    metrics:
+        host:
+            enabled: true
+        process:
+            enabled: false

--- a/internal/commands/config/test/snap4-windows-output.yaml
+++ b/internal/commands/config/test/snap4-windows-output.yaml
@@ -1,8 +1,59 @@
 connectors:
     count: null
+    spanmetrics:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: host.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: otel.status_description
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
+            - host.name
+    spanmetrics/summary:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        dimensions:
+            - name: service.namespace
+            - name: service.version
+            - name: deployment.environment.name
+            - name: peer.db.name
+            - name: peer.messaging.system
+            - name: observe.status_code
+        histogram:
+            exponential:
+                max_size: 100
+        resource_metrics_key_attributes:
+            - service.name
+            - service.namespace
+            - service.version
+            - deployment.environment.name
 exporters:
     debug: null
     nop: null
+    otlphttp/agentheartbeat:
+        compression: zstd
+        headers:
+            Authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            X-Observe-Agent-Instance-Id: test-agent-instance-id
+            X-Observe-Context: '{"environment":"windows","version":"dev"}'
+            X-Observe-Enable-Auth-Error-Reporting: "true"
+            X-Observe-Target-Package: Observe Agent
+        logs_endpoint: https://123456789.collect.observe-eng.com/v1/kubernetes/v1/entity
+        retry_on_failure:
+            enabled: true
+        sending_queue:
+            num_consumers: 4
+            queue_size: 100
     otlphttp/observe:
         compression: zstd
         endpoint: https://123456789.collect.observe-eng.com/v2/otel
@@ -50,13 +101,10 @@ exporters:
         target_info:
             enabled: false
 extensions:
-    cgroupruntime:
-        gomaxprocs:
-            enabled: true
     file_storage:
-        directory: /var/lib/observe-agent/filestorage
+        directory: C:\ProgramData\Observe\observe-agent\filestorage
     health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: localhost:13133
         path: /status
 processors:
     batch:
@@ -67,45 +115,54 @@ processors:
         metrics:
             metric:
                 - IsMatch(name, ".*")
+    filter/drop_long_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - (span.end_time - span.start_time) > Duration("1h")
+    filter/drop_non_apm_spans:
+        error_mode: ignore
+        traces:
+            span:
+                - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+                - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
+                - span.kind == SPAN_KIND_UNSPECIFIED
+                - span.kind == SPAN_KIND_INTERNAL
+    groupbyattrs/peers:
+        keys:
+            - peer.db.name
+            - peer.messaging.system
     memory_limiter:
         check_interval: 1s
         limit_percentage: 80
         spike_limit_percentage: 20
+    metricstransform/rename_summary_metrics:
+        transforms:
+            - action: update
+              include: traces.span.metrics.calls
+              new_name: traces.span.metrics.calls.summary
+            - action: update
+              include: traces.span.metrics.duration
+              new_name: traces.span.metrics.duration.summary
     resource/agent_instance:
         attributes:
             - action: upsert
               key: observe.agent.instance.id
               value: test-agent-instance-id
+    resource/heartbeat:
+        attributes:
+            - action: insert
+              from_attribute: host.name
+              key: observe.agent.hostname
     resourcedetection:
         detectors:
             - env
             - system
         system:
             hostname_sources:
-                - dns
                 - os
             resource_attributes:
-                host.arch:
-                    enabled: true
-                host.cpu.cache.l2.size:
-                    enabled: true
-                host.cpu.family:
-                    enabled: true
-                host.cpu.model.id:
-                    enabled: true
-                host.cpu.model.name:
-                    enabled: true
-                host.cpu.stepping:
-                    enabled: true
-                host.cpu.vendor.id:
-                    enabled: true
                 host.id:
-                    enabled: false
-                host.name:
-                    enabled: true
-                os.description:
-                    enabled: true
-                os.type:
                     enabled: true
     resourcedetection/cloud:
         detectors:
@@ -132,6 +189,55 @@ processors:
             - set(span.attributes["observe.status_code"], Int(span.attributes["rpc.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["rpc.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
             - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
+    transform/fix_red_metrics_resource_attributes:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name|host.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/fix_red_metrics_resource_attributes/summary:
+        error_mode: ignore
+        metric_statements:
+            - keep_matching_keys(resource.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - delete_matching_keys(datapoint.attributes, "^(service.name|service.namespace|service.version|deployment.environment.name)")
+            - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+            - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+            - delete_key(datapoint.attributes, "status.code")
+    transform/heartbeat:
+        error_mode: ignore
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["observe_transform"]["identifiers"]["host.name"], resource.attributes["host.name"])
+                - set(attributes["observe_transform"]["identifiers"]["os.type"], resource.attributes["os.type"])
+    transform/promote_peer_to_service:
+        error_mode: ignore
+        trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+                - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+            - context: span
+              statements:
+                - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+                - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+            - context: resource
+              statements:
+                - delete_key(attributes, "peer.db.name")
+                - delete_key(attributes, "peer.messaging.system")
+    transform/remove_service_name_for_peer_metrics:
+        error_mode: ignore
+        metric_statements:
+            - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
+    transform/shape_spans_for_red_metrics:
+        error_mode: ignore
+        trace_statements:
+            - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
+            - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
+            - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
+            - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
     transform/truncate:
         log_statements:
             - context: log
@@ -144,34 +250,23 @@ processors:
                 - truncate_all(attributes, 4095)
                 - truncate_all(resource.attributes, 4095)
 receivers:
-    filelog/host_monitoring:
-        include:
-            - /hostfs/var/log/**/*.log
-            - /hostfs/var/log/syslog
-        include_file_path: true
-        max_log_size: 4MiB
-        operators:
-            - expr: body matches "otel-contrib"
-              type: filter
-        retry_on_failure:
-            enabled: true
-        storage: file_storage
     filestats/agent:
         collection_interval: 5m
-        include: /etc/observe-agent/observe-agent.yaml
+        include: C:\Program Files\Observe\observe-agent\observe-agent.yaml
         initial_delay: 60s
+    heartbeat:
+        auth_check:
+            headers:
+                authorization: Bearer abcdefghijklmnopqrst:OWt0SXV4YTlqYUhpSHZjSlhXUDVkRXpl
+            url: https://123456789.collect.observe-eng.com
+        config_interval: 24h
+        environment: windows
+        interval: 10m
     hostmetrics/host-monitoring-host:
         collection_interval: 60s
-        root_path: /hostfs
         scrapers:
             cpu:
                 metrics:
-                    system.cpu.frequency:
-                        enabled: true
-                    system.cpu.logical.count:
-                        enabled: true
-                    system.cpu.physical.count:
-                        enabled: true
                     system.cpu.utilization:
                         enabled: true
             disk: null
@@ -182,8 +277,6 @@ receivers:
             load: null
             memory:
                 metrics:
-                    system.linux.memory.available:
-                        enabled: true
                     system.memory.utilization:
                         enabled: true
             network: null
@@ -191,30 +284,13 @@ receivers:
                 metrics:
                     system.paging.utilization:
                         enabled: true
-            processes: null
-    journald/agent:
-        priority: info
-        units:
-            - observe-agent
-    journald/host_monitoring:
-        priority: info
-        units:
-            - cron
-            - ssh
-            - systemd-networkd
-            - systemd-resolved
-            - systemd-login
-            - multipathd
-            - systemd-user-sessions
-            - ufw
-            - observe-agent
     nop: null
     otlp:
         protocols:
             grpc:
-                endpoint: 0.0.0.0:4317
+                endpoint: localhost:4317
             http:
-                endpoint: 0.0.0.0:4318
+                endpoint: localhost:4318
     prometheus/agent:
         config:
             scrape_configs:
@@ -227,19 +303,41 @@ receivers:
                   scrape_interval: 10s
                   static_configs:
                     - targets:
-                        - 0.0.0.0:8888
+                        - localhost:8888
+    windowseventlog/agent:
+        query: |
+            <QueryList>
+              <Query Id="0">
+                <Select Path="Application">*[System[Provider[@Name='ObserveAgent']]]</Select>
+              </Query>
+            </QueryList>
+        retry_on_failure:
+            enabled: true
+    windowseventlog/host_monitoring-application:
+        channel: Application
+        exclude_providers:
+            - ObserveAgent
+        retry_on_failure:
+            enabled: true
+    windowseventlog/host_monitoring-security:
+        channel: Security
+        retry_on_failure:
+            enabled: true
+    windowseventlog/host_monitoring-system:
+        channel: System
+        retry_on_failure:
+            enabled: true
 service:
     extensions:
         - health_check
         - file_storage
-        - cgroupruntime
     pipelines:
         logs/agent-config:
             exporters:
                 - nop
             receivers:
                 - nop
-        logs/agent-journald:
+        logs/agent-windowseventlog:
             exporters:
                 - otlphttp/observe
                 - count
@@ -248,9 +346,10 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - batch
             receivers:
-                - journald/agent
+                - windowseventlog/agent
         logs/forward:
             exporters:
                 - otlphttp/observe
@@ -263,7 +362,18 @@ service:
                 - batch
             receivers:
                 - otlp
-        logs/host_monitoring-file:
+        logs/heartbeat:
+            exporters:
+                - otlphttp/agentheartbeat
+            processors:
+                - resourcedetection
+                - resourcedetection/cloud
+                - resource/agent_instance
+                - resource/heartbeat
+                - transform/heartbeat
+            receivers:
+                - heartbeat
+        logs/host_monitoring-windowsevents:
             exporters:
                 - otlphttp/observe
                 - count
@@ -274,19 +384,9 @@ service:
                 - resourcedetection/cloud
                 - batch
             receivers:
-                - filelog/host_monitoring
-        logs/host_monitoring-journald:
-            exporters:
-                - otlphttp/observe
-                - count
-            processors:
-                - memory_limiter
-                - transform/truncate
-                - resourcedetection
-                - resourcedetection/cloud
-                - batch
-            receivers:
-                - journald/host_monitoring
+                - windowseventlog/host_monitoring-application
+                - windowseventlog/host_monitoring-security
+                - windowseventlog/host_monitoring-system
         metrics/agent-filestats:
             exporters:
                 - prometheusremotewrite/observe
@@ -305,6 +405,7 @@ service:
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
+                - resource/agent_instance
                 - deltatocumulative
                 - batch
             receivers:
@@ -340,17 +441,56 @@ service:
                 - batch
             receivers:
                 - hostmetrics/host-monitoring-host
+        metrics/spanmetrics:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes
+                - batch
+            receivers:
+                - spanmetrics
+        metrics/spanmetrics/summary:
+            exporters:
+                - otlphttp/observemetrics
+            processors:
+                - memory_limiter
+                - transform/remove_service_name_for_peer_metrics
+                - transform/fix_red_metrics_resource_attributes/summary
+                - metricstransform/rename_summary_metrics
+                - batch
+            receivers:
+                - spanmetrics/summary
         traces/forward:
             exporters:
                 - otlphttp/observetracing
             processors:
                 - memory_limiter
+                - filter/drop_long_spans
                 - transform/truncate
                 - resourcedetection
                 - resourcedetection/cloud
                 - transform/add_span_status_code
                 - transform/add_empty_service_attributes
                 - batch
+            receivers:
+                - otlp
+        traces/spanmetrics:
+            exporters:
+                - spanmetrics
+                - spanmetrics/summary
+            processors:
+                - memory_limiter
+                - filter/drop_long_spans
+                - filter/drop_non_apm_spans
+                - resourcedetection
+                - resourcedetection/cloud
+                - transform/shape_spans_for_red_metrics
+                - transform/add_span_status_code
+                - groupbyattrs/peers
+                - transform/promote_peer_to_service
+                - transform/add_empty_service_attributes
             receivers:
                 - otlp
     telemetry:
@@ -363,7 +503,7 @@ service:
                 - pull:
                     exporter:
                         prometheus:
-                            host: 0.0.0.0
+                            host: localhost
                             port: 8888
                             with_resource_constant_labels:
                                 included:

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -99,15 +99,30 @@ type InternalTelemetryConfig struct {
 	Logs    InternalTelemetryLogsConfig    `yaml:"logs" mapstructure:"logs"`
 }
 
+type REDSummaryMetricsConfig struct {
+	// Resource attributes to include as dimensions for summary RED metrics. Summary metrics have
+	// fewer dimensions than the full RED metrics and are named with a .summary suffix.
+	// Altering these dimensions will negatively impact query performance in APM.
+	ResourceDimensions []string `yaml:"resource_dimensions" mapstructure:"resource_dimensions" default:"[service.namespace,service.version,deployment.environment.name]"`
+	// Span attributes to include as dimensions for summary RED metrics. Altering these dimensions
+	// will negatively impact query performance in APM.
+	SpanDimensions []string `yaml:"span_dimensions" mapstructure:"span_dimensions" default:"[peer.db.name,peer.messaging.system,observe.status_code]"`
+}
+
 type REDMetricsConfig struct {
 	Enabled bool `yaml:"enabled" mapstructure:"enabled" default:"false"`
-	// If enabled, this will skip generating RED metrics for spans that are not service entrypoint spans
-	// (which are spans with kind Server, kind Consumer, or calls to DB or messaging system clients).
-	// This will limit the metrics created to only those directly used in Observe APM.
-	OnlyGenerateForServiceEntrypointSpans bool `yaml:"only_generate_for_service_entrypoint_spans" mapstructure:"only_generate_for_service_entrypoint_spans" default:"false"`
+	// If enabled, this will skip generating RED metrics for spans that are not considered to be
+	// top level in APM (which are spans with kind Server, kind Consumer, or calls to DB or
+	// messaging system clients). If this is set to false, metrics generated for non-APM spans
+	// will be suffixed with `.internal`. If this flag and trace sampling are both enabled, it
+	// will not be possible to deduce accurate RED metrics for non-APM spans.
+	OnlyGenerateForAPMSpans bool `yaml:"only_generate_for_apm_spans" mapstructure:"only_generate_for_apm_spans" default:"true"`
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#overview
-	ResourceDimensions []string `yaml:"resource_dimensions" mapstructure:"resource_dimensions" default:"[service.namespace,service.version,deployment.environment]"`
+	// SetViperDefaults appends `container.id` when configMode is "docker".
+	ResourceDimensions []string `yaml:"resource_dimensions" mapstructure:"resource_dimensions" default:"[service.namespace,service.version,deployment.environment.name,host.name]"`
 	SpanDimensions     []string `yaml:"span_dimensions" mapstructure:"span_dimensions" default:"[peer.db.name,peer.messaging.system,otel.status_description,observe.status_code]"`
+	// SummaryMetrics controls the lower-cardinality `.summary` RED metrics emitted in parallel.
+	SummaryMetrics REDSummaryMetricsConfig `yaml:"summary_metrics" mapstructure:"summary_metrics"`
 }
 
 type ApplicationConfig struct {
@@ -159,6 +174,8 @@ func SetViperDefaults(v *viper.Viper, separator string, configMode string) {
 		config.Forwarding.Endpoints.GRPC = "0.0.0.0:4317"
 		config.HealthCheck.Endpoint = "0.0.0.0:13133"
 		config.InternalTelemetry.Metrics.Host = "0.0.0.0"
+		// Identify metric streams by container.id in addition to host.name (which is the docker host).
+		config.Application.REDMetrics.ResourceDimensions = append(config.Application.REDMetrics.ResourceDimensions, "container.id")
 	}
 	var confMap map[string]any
 	err := mapstructure.Decode(config, &confMap)

--- a/internal/config/configschema_test.go
+++ b/internal/config/configschema_test.go
@@ -110,29 +110,69 @@ func TestAgentConfigValidate(t *testing.T) {
 func TestAgentConfigFromViper(t *testing.T) {
 	config, err := AgentConfigFromViper(nil)
 	assert.Error(t, err, "no viper instance provided")
+	assert.Nil(t, config)
 
-	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
-	v.Set("token", "some:token")
-	v.Set("observe_url", "https://observeinc.com")
-	v.Set("host_monitoring::enabled", true)
-	v.Set("resource_attributes", map[string]string{"deployment.environment.name": "test"})
-	config, err = AgentConfigFromViper(v)
-	assert.NoError(t, err)
-	assert.Equal(t, "some:token", config.Token)
-	assert.Equal(t, "https://observeinc.com", config.ObserveURL)
-	assert.Equal(t, true, config.HostMonitoring.Enabled)
-	assert.Equal(t, "test", config.ResourceAttributes["deployment.environment.name"])
+	type viperCase struct {
+		name       string
+		options    map[string]any
+		configMode string
+		validate   func(t *testing.T, config *AgentConfig)
+	}
 
-	// Validate that defaults are set when the value is not in the viper config
-	assert.Equal(t, true, config.HealthCheck.Enabled)
-	assert.Equal(t, true, config.Forwarding.Enabled)
+	cases := []viperCase{
+		{
+			name: "set values stick and unset values fall back to defaults",
+			options: map[string]any{
+				"token":                    "some:token",
+				"observe_url":              "https://observeinc.com",
+				"host_monitoring::enabled": true,
+				"resource_attributes":      map[string]string{"deployment.environment.name": "test"},
+			},
+			configMode: "linux",
+			validate: func(t *testing.T, config *AgentConfig) {
+				assert.Equal(t, "some:token", config.Token)
+				assert.Equal(t, "https://observeinc.com", config.ObserveURL)
+				assert.Equal(t, true, config.HostMonitoring.Enabled)
+				assert.Equal(t, "test", config.ResourceAttributes["deployment.environment.name"])
 
-	// Validate that defaults are overridden by present values
-	v.Set("health_check::enabled", false)
-	config, err = AgentConfigFromViper(v)
-	assert.NoError(t, err)
-	assert.Equal(t, false, config.HealthCheck.Enabled)
-	assert.Equal(t, true, config.Forwarding.Enabled)
+				// Defaults should be present when the value is not in the viper config.
+				assert.Equal(t, true, config.HealthCheck.Enabled)
+				assert.Equal(t, true, config.Forwarding.Enabled)
+			},
+		},
+		{
+			name: "user-supplied RED_metrics resource_dimensions in docker mode are not augmented with container.id",
+			options: map[string]any{
+				"token":                             "some:token",
+				"observe_url":                       "https://observeinc.com",
+				"application::RED_metrics::enabled": true,
+				"application::RED_metrics::resource_dimensions": []string{"service.namespace", "service.version"},
+			},
+			configMode: "docker",
+			validate: func(t *testing.T, config *AgentConfig) {
+				assert.Equal(t, true, config.Application.REDMetrics.Enabled)
+				assert.Equal(t, []string{"service.namespace", "service.version"}, config.Application.REDMetrics.ResourceDimensions)
+				assert.NotContains(t, config.Application.REDMetrics.ResourceDimensions, "container.id")
+				assert.NotContains(t, config.Application.REDMetrics.ResourceDimensions, "host.name")
+
+				// OnlyGenerateForAPMSpans should default to true.
+				assert.Equal(t, true, config.Application.REDMetrics.OnlyGenerateForAPMSpans)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.NewWithOptions(viper.KeyDelimiter("::"))
+			SetViperDefaults(v, "::", tc.configMode)
+			for k, val := range tc.options {
+				v.Set(k, val)
+			}
+			config, err := AgentConfigFromViper(v)
+			assert.NoError(t, err)
+			tc.validate(t, config)
+		})
+	}
 }
 
 func TestSetViperDefaultsDockerConfigMode(t *testing.T) {
@@ -143,6 +183,8 @@ func TestSetViperDefaultsDockerConfigMode(t *testing.T) {
 	assert.Equal(t, "0.0.0.0:4317", v.GetString("forwarding::endpoints::grpc"))
 	assert.Equal(t, "0.0.0.0:13133", v.GetString("health_check::endpoint"))
 	assert.Equal(t, "0.0.0.0", v.GetString("internal_telemetry::metrics::host"))
+	assert.Contains(t, v.GetStringSlice("application::RED_metrics::resource_dimensions"), "container.id")
+	assert.Contains(t, v.GetStringSlice("application::RED_metrics::resource_dimensions"), "host.name")
 }
 
 func TestSetViperDefaultsNonDockerConfigMode(t *testing.T) {
@@ -153,4 +195,6 @@ func TestSetViperDefaultsNonDockerConfigMode(t *testing.T) {
 	assert.Equal(t, "localhost:4317", v.GetString("forwarding::endpoints::grpc"))
 	assert.Equal(t, "localhost:13133", v.GetString("health_check::endpoint"))
 	assert.Equal(t, "localhost", v.GetString("internal_telemetry::metrics::host"))
+	assert.Contains(t, v.GetStringSlice("application::RED_metrics::resource_dimensions"), "host.name")
+	assert.NotContains(t, v.GetStringSlice("application::RED_metrics::resource_dimensions"), "container.id")
 }

--- a/internal/connections/bundledconfig/shared/application/RED_metrics.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/application/RED_metrics.yaml.tmpl
@@ -4,6 +4,13 @@ connectors:
     histogram:
       exponential:
         max_size: 100
+    # Limit the resource attributes used to bucket aggregated metric streams. Without
+    # this, the connector hashes ALL span resource attributes and emits a separate
+    # ResourceMetrics envelope per unique combination, causing per-pod fanout.
+    resource_metrics_key_attributes:
+      {{- range (prepend .Application.REDMetrics.ResourceDimensions "service.name" | uniq) }}
+      - {{ . }}
+      {{- end }}
     dimensions:
       # This connector implicitly adds: service.name, span.name, span.kind, and status.code (which we rename to response_status)
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/connector.go#L528-L540
@@ -17,6 +24,53 @@ connectors:
       - name: {{ . }}
       {{- end }}
 
+  spanmetrics/summary:
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      exponential:
+        max_size: 100
+    # See note on spanmetrics.resource_metrics_key_attributes above.
+    resource_metrics_key_attributes:
+      {{- range (prepend .Application.REDMetrics.SummaryMetrics.ResourceDimensions "service.name" | uniq) }}
+      - {{ . }}
+      {{- end }}
+    dimensions:
+      {{- $summaryDimensions := concat .Application.REDMetrics.SummaryMetrics.ResourceDimensions .Application.REDMetrics.SummaryMetrics.SpanDimensions }}
+      {{- range ($summaryDimensions | uniq) }}
+      {{- if not (eq . "service.name") }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}
+
+  {{- if not .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+  # Routes RED metric datapoints generated from spans that would have been dropped by
+  # filter/drop_non_apm_spans (i.e. INTERNAL, UNSPECIFIED, non-DB CLIENT, non-messaging
+  # PRODUCER) to a dedicated pipeline that renames them with an ".internal" suffix.
+  # All other datapoints go to the default pipeline.
+  #
+  # NB: the route() condition below mirrors the inverse of filter/drop_non_apm_spans.
+  # Keep the two in sync.
+  routing/red_metrics_internal:
+    error_mode: ignore
+    default_pipelines: [metrics/spanmetrics/default]
+    table:
+      - context: datapoint
+        statement: |
+          route() where
+            attributes["span.kind"] == "SPAN_KIND_INTERNAL"
+            or attributes["span.kind"] == "SPAN_KIND_UNSPECIFIED"
+            or (attributes["span.kind"] == "SPAN_KIND_CLIENT"
+                and attributes["peer.db.name"] == nil)
+            or (attributes["span.kind"] == "SPAN_KIND_PRODUCER"
+                and attributes["peer.messaging.system"] == nil)
+        pipelines: [metrics/spanmetrics/internal]
+
+  # Forwards spans from the main traces/spanmetrics pipeline through an intermediate
+  # filter pipeline (traces/spanmetrics/summary/filter) that drops non-APM spans before
+  # they reach the summary connector.
+  forward/red_metrics_summary:
+  {{- end }}
+
 processors:
   # This handles schema normalization as well as moving status to attributes so it can be a dimension in spanmetrics
   transform/shape_spans_for_red_metrics:
@@ -25,24 +79,40 @@ processors:
       # peer.db.name = coalesce(peer.db.name, db.system.name, db.system)
       - set(span.attributes["peer.db.name"], span.attributes["db.system.name"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] != nil
       - set(span.attributes["peer.db.name"], span.attributes["db.system"]) where span.attributes["peer.db.name"] == nil and span.attributes["db.system"] != nil
-      # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
-      - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+      # peer.messaging.system = coalesce(peer.messaging.system, messaging.system)
+      - set(span.attributes["peer.messaging.system"], span.attributes["messaging.system"]) where span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] != nil
       # Needed because `spanmetrics` connector can only operate on attributes or resource attributes.
       - set(span.attributes["otel.status_description"], span.status.message) where span.status.message != ""
 
-  # This regroups the metrics by the peer attributes so we can remove `service.name` from the resource when these metric attributes are present
-  # NB: these will be deleted from the metric attributes and added to the resource.
+  # This regroups the spans by the peer attributes so we can override `service.name` based on the peer system.
+  # NB: these will be deleted from the span attributes and added to the resource.
   groupbyattrs/peers:
     keys:
       - peer.db.name
       - peer.messaging.system
 
-  # This puts moves the peer attributes from the resource back to the datapoint after we have regrouped the metrics.
-  transform/fix_peer_attributes:
+  # Sets `service.name` to `peer.db.name` (or `peer.messaging.system`) when present, then moves
+  # the peer attributes back from the resource onto each span. Explicit `context:` blocks ensure
+  # resource-scoped statements run once per resource (not once per span).
+  transform/promote_peer_to_service:
     error_mode: ignore
-    metric_statements:
-      - set(datapoint.attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
-      - set(datapoint.attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+    trace_statements:
+      - context: resource
+        statements:
+          # service.name = peer.db.name if peer.db.name != nil
+          - set(attributes["service.name"], attributes["peer.db.name"]) where attributes["peer.db.name"] != nil
+          # service.name = peer.messaging.system if peer.messaging.system != nil and peer.db.name == nil
+          - set(attributes["service.name"], attributes["peer.messaging.system"]) where attributes["peer.messaging.system"] != nil and attributes["peer.db.name"] == nil
+      - context: span
+        statements:
+          # Move peer.* back onto each span's own attributes (resource still intact here)
+          - set(attributes["peer.db.name"], resource.attributes["peer.db.name"]) where resource.attributes["peer.db.name"] != nil
+          - set(attributes["peer.messaging.system"], resource.attributes["peer.messaging.system"]) where resource.attributes["peer.messaging.system"] != nil
+      - context: resource
+        statements:
+          # Delete peer.* from the resource AFTER all spans have copied them locally
+          - delete_key(attributes, "peer.db.name")
+          - delete_key(attributes, "peer.messaging.system")
 
   # This removes service.name for generated RED metrics associated with peer systems.
   transform/remove_service_name_for_peer_metrics:
@@ -50,17 +120,18 @@ processors:
     metric_statements:
       - delete_key(resource.attributes, "service.name") where datapoint.attributes["peer.db.name"] != nil or datapoint.attributes["peer.messaging.system"] != nil
 
-  {{- if .Application.REDMetrics.OnlyGenerateForServiceEntrypointSpans }}
-  # This is used in the RED metrics generation pipeline to drop data that is not used in Observe APM.
-  filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client:
+  # This drops spans (and thus RED metric data) for span kinds that are not relevant to the Observe APM offering.
+  # If you use RED metrics outside of APM, then we recommend disabling this filter and generating RED metrics for all span kinds.
+  # NB: connectors/routing/red_metrics_internal encodes the inverse of this filter on the metrics side. Keep the two in sync.
+  filter/drop_non_apm_spans:
     error_mode: ignore
     traces:
       span:
-        - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.messaging.system"] == nil and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+        # We are keeping: all SERVER spans, all CONSUMER spans, CLIENT spans with a peer db, and PRODUCER spans with a peer messaging system.
+        - span.kind == SPAN_KIND_CLIENT and span.attributes["peer.db.name"] == nil and span.attributes["db.system.name"] == nil and span.attributes["db.system"] == nil
+        - span.kind == SPAN_KIND_PRODUCER and span.attributes["peer.messaging.system"] == nil and span.attributes["messaging.system"] == nil
         - span.kind == SPAN_KIND_UNSPECIFIED
         - span.kind == SPAN_KIND_INTERNAL
-        - span.kind == SPAN_KIND_PRODUCER
-  {{- end }}
 
   # The spanmetrics connector puts all dimensions as attributes on the datapoint, and copies the resource attributes from an arbitrary span's resource. This cleans that up as well as handling any other renaming.
   transform/fix_red_metrics_resource_attributes:
@@ -77,6 +148,43 @@ processors:
       - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
       - delete_key(datapoint.attributes, "status.code")
 
+  transform/fix_red_metrics_resource_attributes/summary:
+    error_mode: ignore
+    metric_statements:
+      # Drop all resource attributes that aren't dimensions in the summary spanmetrics connector.
+      - keep_matching_keys(resource.attributes, "^({{ join "|" (concat (list "service.name") .Application.REDMetrics.SummaryMetrics.ResourceDimensions | uniq) }})")
+
+      # Drop all datapoint attributes that are resource attributes on the spans.
+      - delete_matching_keys(datapoint.attributes, "^({{ join "|" (concat (list "service.name") .Application.REDMetrics.SummaryMetrics.ResourceDimensions | uniq) }})")
+
+      # Rename status.code to response_status to be consistent with Trace Explorer and disambiguate from status_code (with an underscore).
+      - set(datapoint.attributes["otel.status_code"], "OK") where datapoint.attributes["status.code"] == "STATUS_CODE_OK"
+      - set(datapoint.attributes["otel.status_code"], "ERROR") where datapoint.attributes["status.code"] == "STATUS_CODE_ERROR"
+      - delete_key(datapoint.attributes, "status.code")
+
+  metricstransform/rename_summary_metrics:
+    transforms:
+      - include: traces.span.metrics.calls
+        action: update
+        new_name: traces.span.metrics.calls.summary
+      - include: traces.span.metrics.duration
+        action: update
+        new_name: traces.span.metrics.duration.summary
+
+  {{- if not .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+  # Renames RED metrics from non-entrypoint (would-have-been-dropped) spans with an ".internal"
+  # suffix. This processor lives on the metrics/spanmetrics/internal pipeline, downstream of
+  # routing/red_metrics_internal, so every datapoint it sees is already known to be "internal".
+  metricstransform/rename_internal_metrics:
+    transforms:
+      - include: traces.span.metrics.calls
+        action: update
+        new_name: traces.span.metrics.calls.internal
+      - include: traces.span.metrics.duration
+        action: update
+        new_name: traces.span.metrics.duration.internal
+  {{- end }}
+
 service:
   pipelines:
     traces/spanmetrics:
@@ -87,26 +195,91 @@ service:
         {{- if ne .Forwarding.Traces.MaxSpanDuration "none" }}
         - filter/drop_long_spans
         {{- end }}
-        {{- if .Application.REDMetrics.OnlyGenerateForServiceEntrypointSpans }}
-        - filter/drop_span_kinds_other_than_server_and_consumer_and_peer_client
+        {{- if .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+        - filter/drop_non_apm_spans
         {{- end }}
+        - resourcedetection
+        - resourcedetection/cloud
         - transform/shape_spans_for_red_metrics
         - transform/add_span_status_code
-        - resource/add_empty_service_attributes
+        # Regroup by the peer attributes so we can override the service.name when we have a peer server.
+        - groupbyattrs/peers
+        - transform/promote_peer_to_service
+        - transform/add_empty_service_attributes
       exporters:
         - spanmetrics
+        {{- if .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+        - spanmetrics/summary
+        {{- else }}
+        # When only_generate_for_apm_spans is off, the main pipeline includes non-APM spans.
+        # The summary connector must only see APM spans, so we forward through an intermediate
+        # pipeline that applies filter/drop_non_apm_spans before feeding spanmetrics/summary.
+        - forward/red_metrics_summary
+        {{- end }}
 
     metrics/spanmetrics:
       receivers:
         - spanmetrics
       processors:
         - memory_limiter
-        - groupbyattrs/peers
-        - transform/fix_peer_attributes
         - transform/remove_service_name_for_peer_metrics
         - transform/fix_red_metrics_resource_attributes
-        - resourcedetection
-        - resourcedetection/cloud
+        {{- if .HasAttributes }}
+        - attributes/observe_global_attributes
+        {{- end }}
+        {{- if .HasResourceAttributes }}
+        - resource/observe_global_resource_attributes
+        {{- end }}
+        {{- if not .Exporters.SendingQueueBatch.Enabled }}
+        - batch
+        {{- end }}
+      exporters:
+        {{- if .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+        - otlphttp/observemetrics
+        {{- else }}
+        # When only_generate_for_apm_spans is off, RED metrics are generated for span kinds that
+        # would otherwise be dropped. Route them so the "internal" kinds can be renamed with an
+        # ".internal" suffix; entrypoint kinds pass through the default pipeline unchanged.
+        - routing/red_metrics_internal
+        {{- end }}
+
+    {{- if not .Application.REDMetrics.OnlyGenerateForAPMSpans }}
+    metrics/spanmetrics/default:
+      receivers:
+        - routing/red_metrics_internal
+      processors:
+        - memory_limiter
+      exporters:
+        - otlphttp/observemetrics
+
+    metrics/spanmetrics/internal:
+      receivers:
+        - routing/red_metrics_internal
+      processors:
+        - memory_limiter
+        - metricstransform/rename_internal_metrics
+      exporters:
+        - otlphttp/observemetrics
+
+    # Intermediate pipeline: filters non-APM spans before feeding the summary connector.
+    traces/spanmetrics/summary/filter:
+      receivers:
+        - forward/red_metrics_summary
+      processors:
+        - memory_limiter
+        - filter/drop_non_apm_spans
+      exporters:
+        - spanmetrics/summary
+    {{- end }}
+
+    metrics/spanmetrics/summary:
+      receivers:
+        - spanmetrics/summary
+      processors:
+        - memory_limiter
+        - transform/remove_service_name_for_peer_metrics
+        - transform/fix_red_metrics_resource_attributes/summary
+        - metricstransform/rename_summary_metrics
         {{- if .HasAttributes }}
         - attributes/observe_global_attributes
         {{- end }}

--- a/internal/connections/bundledconfig/shared/common/forward.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/common/forward.yaml.tmpl
@@ -16,18 +16,22 @@ processors:
       - set(span.attributes["observe.status_code"], Int(span.attributes["http.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.status_code"] != nil
       - set(span.attributes["observe.status_code"], Int(span.attributes["http.response.status_code"])) where span.attributes["observe.status_code"] == nil and span.attributes["http.response.status_code"] != nil
 
-  # Always add service.name, service.namespace, and deployment.environment to the resource attributes.
-  resource/add_empty_service_attributes:
-    attributes:
-      - key: service.name
-        value: ""
-        action: insert
-      - key: service.namespace
-        value: ""
-        action: insert
-      - key: deployment.environment
-        value: ""
-        action: insert
+  # Normalizes deployment environment (coalescing between the deprecated
+  # `deployment.environment` and `deployment.environment.name`) and defaults the
+  # service / environment resource attributes so they are always present on
+  # forwarded traces.
+  transform/add_empty_service_attributes:
+    error_mode: ignore
+    trace_statements:
+      # deployment.environment.name = coalesce(deployment.environment.name, deployment.environment)
+      - set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil
+      # deployment.environment = coalesce(deployment.environment, deployment.environment.name)
+      - set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment"] == nil and resource.attributes["deployment.environment.name"] != nil
+      # Default any still-missing attributes to an empty string.
+      - set(resource.attributes["service.name"], "") where resource.attributes["service.name"] == nil
+      - set(resource.attributes["service.namespace"], "") where resource.attributes["service.namespace"] == nil
+      - set(resource.attributes["deployment.environment.name"], "") where resource.attributes["deployment.environment.name"] == nil
+      - set(resource.attributes["deployment.environment"], "") where resource.attributes["deployment.environment"] == nil
 
 {{- if ne .Forwarding.Traces.MaxSpanDuration "none" }}
   # This drops spans that are longer than the configured time (default 1hr) to match service explorer behavior.
@@ -147,7 +151,7 @@ service:
         {{- if .HasResourceAttributes }}
         - resource/observe_global_resource_attributes
         {{- end }}
-        - resource/add_empty_service_attributes
+        - transform/add_empty_service_attributes
         {{- if not .Exporters.SendingQueueBatch.Enabled }}
         - batch
         {{- end }}

--- a/observe-agent.schema.json
+++ b/observe-agent.schema.json
@@ -296,9 +296,30 @@
         "enabled": {
           "type": "boolean"
         },
-        "only_generate_for_service_entrypoint_spans": {
+        "only_generate_for_apm_spans": {
           "type": "boolean"
         },
+        "resource_dimensions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "span_dimensions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary_metrics": {
+          "$ref": "#/$defs/REDSummaryMetricsConfig"
+        }
+      },
+      "type": "object"
+    },
+    "REDSummaryMetricsConfig": {
+      "additionalProperties": false,
+      "properties": {
         "resource_dimensions": {
           "items": {
             "type": "string"

--- a/observecol/feature_gates.go
+++ b/observecol/feature_gates.go
@@ -23,6 +23,7 @@ var internalFeatureFlagDefaults = map[string]bool{
 	"connector.spanmetrics.useSecondAsDefaultMetricsUnit":         false,
 	"connector.spanmetrics.excludeResourceMetrics":                false,
 	"processor.tailsamplingprocessor.disableinvertdecisions":      false,
+	"connector.spanmetrics.includeCollectorInstanceID":            true,
 }
 
 func AddFeatureGateFlag(flags *pflag.FlagSet) {


### PR DESCRIPTION
### Description

OB-54347: After internal testing, we determined the Observe product experience for observe-agent RED metrics needed to be improved for performance. This change does the following:

- emit a new set of RED metrics with the `.summary` suffix, which will only have the dimensions present in the BE service metrics
- the RED metrics flag `only_generate_for_service_entrypoint_spans` is renamed to `only_generate_for_apm_spans` for clarity and will default to true
- when `only_generate_for_apm_spans` is turned off, the internal (and other non-APM) span RED metrics will be renamed to have a `.internal` suffix
- default to using `deployment.environment.name` instead of `deployment.environment`


Helm chart PR: https://github.com/observeinc/helm-charts/pull/481