### PR TITLE
feat: add emit_prometheus_target_info_metric config value, default to false so target_info metrics will no longer be written

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ tfplan
 *pycache*
 *.pyc
 
+#tooling
+.snowflake/cortex/plans

--- a/internal/commands/config/test/snap0-docker-output.yaml
+++ b/internal/commands/config/test/snap0-docker-output.yaml
@@ -47,6 +47,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     cgroupruntime:
         gomaxprocs:

--- a/internal/commands/config/test/snap0-linux-output.yaml
+++ b/internal/commands/config/test/snap0-linux-output.yaml
@@ -47,6 +47,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap0-macos-output.yaml
+++ b/internal/commands/config/test/snap0-macos-output.yaml
@@ -47,6 +47,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap0-windows-output.yaml
+++ b/internal/commands/config/test/snap0-windows-output.yaml
@@ -47,6 +47,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: C:\ProgramData\Observe\observe-agent\filestorage

--- a/internal/commands/config/test/snap1-docker-output.yaml
+++ b/internal/commands/config/test/snap1-docker-output.yaml
@@ -76,6 +76,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: true
 extensions:
     cgroupruntime:
         gomaxprocs:

--- a/internal/commands/config/test/snap1-full-agent-config.yaml
+++ b/internal/commands/config/test/snap1-full-agent-config.yaml
@@ -84,3 +84,6 @@ application:
             - customer_id
 
 otel_config_overrides: {}
+
+exporters:
+    emit_prometheus_target_info_metric: true

--- a/internal/commands/config/test/snap1-linux-output.yaml
+++ b/internal/commands/config/test/snap1-linux-output.yaml
@@ -76,6 +76,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: true
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap1-macos-output.yaml
+++ b/internal/commands/config/test/snap1-macos-output.yaml
@@ -76,6 +76,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: true
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap1-windows-output.yaml
+++ b/internal/commands/config/test/snap1-windows-output.yaml
@@ -76,6 +76,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: true
 extensions:
     file_storage:
         directory: C:\ProgramData\Observe\observe-agent\filestorage

--- a/internal/commands/config/test/snap3-docker-output.yaml
+++ b/internal/commands/config/test/snap3-docker-output.yaml
@@ -62,6 +62,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     cgroupruntime:
         gomaxprocs:

--- a/internal/commands/config/test/snap3-linux-output.yaml
+++ b/internal/commands/config/test/snap3-linux-output.yaml
@@ -62,6 +62,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap3-macos-output.yaml
+++ b/internal/commands/config/test/snap3-macos-output.yaml
@@ -62,6 +62,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: /var/lib/observe-agent/filestorage

--- a/internal/commands/config/test/snap3-windows-output.yaml
+++ b/internal/commands/config/test/snap3-windows-output.yaml
@@ -62,6 +62,8 @@ exporters:
         resource_to_telemetry_conversion:
             enabled: true
         send_metadata: true
+        target_info:
+            enabled: false
 extensions:
     file_storage:
         directory: C:\ProgramData\Observe\observe-agent\filestorage

--- a/internal/config/configschema.go
+++ b/internal/config/configschema.go
@@ -120,7 +120,8 @@ type SendingQueueBatchConfig struct {
 }
 
 type ExportersConfig struct {
-	SendingQueueBatch SendingQueueBatchConfig `yaml:"sending_queue_batch,omitempty" mapstructure:"sending_queue_batch"`
+	SendingQueueBatch              SendingQueueBatchConfig `yaml:"sending_queue_batch,omitempty" mapstructure:"sending_queue_batch"`
+	EmitPrometheusTargetInfoMetric bool                    `yaml:"emit_prometheus_target_info_metric" mapstructure:"emit_prometheus_target_info_metric"`
 }
 
 type AgentConfig struct {

--- a/internal/connections/bundledconfig/shared/common/base.yaml.tmpl
+++ b/internal/connections/bundledconfig/shared/common/base.yaml.tmpl
@@ -72,6 +72,8 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true  # Convert resource attributes to metric labels
     send_metadata: true
+    target_info:
+      enabled: {{ .Exporters.EmitPrometheusTargetInfoMetric }}
 
   debug:
   nop:

--- a/observe-agent.schema.json
+++ b/observe-agent.schema.json
@@ -80,6 +80,9 @@
     "ExportersConfig": {
       "additionalProperties": false,
       "properties": {
+        "emit_prometheus_target_info_metric": {
+          "type": "boolean"
+        },
         "sending_queue_batch": {
           "$ref": "#/$defs/SendingQueueBatchConfig"
         }


### PR DESCRIPTION
### Description

Observe doesn't use the `target_info` metric, so this turns off emitting `target_info` by default.

### Checklist
- [x] Created tests which fail without the change (if possible)