### PR TITLE
chore: upgrade alpine, bump git actions, ignore CVEs that do not affect us

### DIFF
--- a/.github/workflows/code-gen-check.yaml
+++ b/.github/workflows/code-gen-check.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.14.1

--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -15,7 +15,7 @@ jobs:
       PROJECT_KEY: observeinc-observe-agent
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -45,19 +45,19 @@ jobs:
       TEST_TAG: observeinc/observe-agent:test
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
           cache: false
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.14.1

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
@@ -57,13 +57,13 @@ jobs:
             goarch: "386"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.8
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 20
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.15.4
@@ -95,13 +95,13 @@ jobs:
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
 
@@ -115,7 +115,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@v0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 35
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.15.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,12 +43,12 @@ jobs:
             goarch: "386"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.8
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 20
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.15.4
@@ -80,12 +80,12 @@ jobs:
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
 
@@ -99,7 +99,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@v0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 25
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.15.4

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -41,11 +41,11 @@ jobs:
             goarch: amd64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
       - name: Install qemu
@@ -56,7 +56,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Run GoReleaser
         timeout-minutes: 40
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.15.4
@@ -106,7 +106,7 @@ jobs:
         working-directory: integration #Terrafrom commands and tests are ran from integration directory
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: git branch && df -h
       - name: Configure AWS Credentials ## Terraform provider automatically uses these creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}

--- a/.github/workflows/vuln-check-full.yaml
+++ b/.github/workflows/vuln-check-full.yaml
@@ -19,27 +19,27 @@ jobs:
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.14.1
@@ -64,4 +64,6 @@ jobs:
           ignore-base: true
           ignore-unchanged: true
           only-fixed: false
+          vex-location: .vex/
+          vex-author: Observe Agent Team <observe-agent@observeinc.com>
           exit-code: true

--- a/.github/workflows/vuln-check-release.yaml
+++ b/.github/workflows/vuln-check-release.yaml
@@ -18,27 +18,27 @@ jobs:
     runs-on: ubuntu-observe-agent-8cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.10
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: 2.14.1
@@ -64,4 +64,6 @@ jobs:
           ignore-unchanged: true
           only-fixed: true
           only-severities: medium,critical,high
+          vex-location: .vex/
+          vex-author: Observe Agent Team <observe-agent@observeinc.com>
           exit-code: true

--- a/.vex/observe-agent.openvex.json
+++ b/.vex/observe-agent.openvex.json
@@ -1,0 +1,73 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/observeinc/observe-agent/.vex/observe-agent.openvex.json",
+  "author": "Observe Agent Team <observe-agent@observeinc.com>",
+  "timestamp": "2026-05-15T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/observeinc/observe-agent@test",
+          "subcomponents": [
+            { "@id": "pkg:golang/github.com/prometheus/prometheus@0.311.2-0.20260410083055-07c6232d159b" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "observe-agent vendors github.com/prometheus/prometheus as a library for receiver/exporter code paths only. The Prometheus server HTTP/UI/query surface affected by this CVE is not initialized or exposed by the agent."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/observeinc/observe-agent@test",
+          "subcomponents": [
+            { "@id": "pkg:golang/github.com/prometheus/prometheus@0.311.2-0.20260410083055-07c6232d159b" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "observe-agent vendors github.com/prometheus/prometheus as a library for receiver/exporter code paths only. The Prometheus server HTTP/UI/query surface affected by this CVE is not initialized or exposed by the agent."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/observeinc/observe-agent@test",
+          "subcomponents": [
+            { "@id": "pkg:golang/github.com/prometheus/prometheus@0.311.2-0.20260410083055-07c6232d159b" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "observe-agent vendors github.com/prometheus/prometheus as a library for receiver/exporter code paths only. The Prometheus server HTTP/UI surface where this XSS lands is not initialized or exposed by the agent."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41602"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/observeinc/observe-agent@test",
+          "subcomponents": [
+            { "@id": "pkg:golang/github.com/apache/thrift@0.22.0" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "observe-agent uses github.com/apache/thrift only via the jaeger receiver decode path. The agent does not expose unbounded attacker-controlled framed Thrift messages on a public listener, so the integer-overflow code path is not reachable in deployed agent configurations."
+    }
+  ]
+}

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -9,10 +9,10 @@ RUN tar czhf journalctl.tar.gz /bin/journalctl $(ldd /bin/journalctl | grep -oP 
 # however, we can copy full directory as root (/) to be base file structure for scratch image
 RUN mkdir /output && tar xf /journalctl.tar.gz --directory /output
 
-FROM alpine:3.23.3 AS certs
+FROM alpine:3.23.4 AS certs
 RUN apk --update add ca-certificates
 
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 ARG USER_UID=10001
 ARG USER_GID=10001


### PR DESCRIPTION
To test, I temporarily set `only-fixed` to `false` in our full check, and verified that the scout check passed: https://github.com/observeinc/observe-agent/actions/runs/25936385230