### PR TITLE
init-config: expose all AgentConfig fields as CLI flags + fix fleet default

### DIFF
--- a/internal/commands/initconfig/initconfig.go
+++ b/internal/commands/initconfig/initconfig.go
@@ -14,23 +14,65 @@ import (
 )
 
 var (
-	config_path                                   string
-	token                                         string
-	observe_url                                   string
-	cloud_resource_detectors                      []string
-	resource_attributes                           map[string]string
+	config_path string
+
+	// Top-level
+	token                 string
+	observe_url           string
+	cloud_resource_detectors []string
+	attributes            map[string]string
+	resource_attributes   map[string]string
+	omit_base_components  bool
+	agent_local_file_path string
+
+	// application.RED_metrics
+	application_RED_metrics_enabled                                       bool
+	application_RED_metrics_only_generate_for_service_entrypoint_spans    bool
+	application_RED_metrics_resource_dimensions                           []string
+	application_RED_metrics_span_dimensions                               []string
+
+	// health_check
+	health_check_enabled  bool
+	health_check_endpoint string
+	health_check_path     string
+
+	// forwarding
+	forwarding_enabled                            bool
+	forwarding_endpoints_http                     string
+	forwarding_endpoints_grpc                     string
 	forwarding_metrics_format                     string
-	application_RED_metrics_enabled               bool
-	self_monitoring_enabled                       bool
+	forwarding_metrics_convert_cumulative_to_delta bool
+	forwarding_traces_max_span_duration           string
+
+	// internal_telemetry
+	internal_telemetry_enabled         bool
+	internal_telemetry_metrics_enabled bool
+	internal_telemetry_metrics_host    string
+	internal_telemetry_metrics_port    int
+	internal_telemetry_metrics_level   string
+	internal_telemetry_logs_enabled    bool
+	internal_telemetry_logs_level      string
+	internal_telemetry_logs_encoding   string
+
+	// self_monitoring
+	self_monitoring_enabled               bool
+	self_monitoring_fleet_enabled         bool
+	self_monitoring_fleet_interval        string
+	self_monitoring_fleet_config_interval string
+
+	// host_monitoring
 	host_monitoring_enabled                       bool
 	host_monitoring_logs_enabled                  bool
 	host_monitoring_logs_include                  []string
+	host_monitoring_logs_exclude                  []string
 	host_monitoring_logs_auto_multiline_detection bool
 	host_monitoring_metrics_host_enabled          bool
 	host_monitoring_metrics_process_enabled       bool
-	self_monitoring_fleet_enabled                 bool
-	self_monitoring_fleet_interval                string
-	self_monitoring_fleet_config_interval         string
+
+	// exporters
+	exporters_sending_queue_batch_enabled        bool
+	exporters_sending_queue_batch_max_size       int
+	exporters_emit_prometheus_target_info_metric bool
 )
 
 func NewConfigureCmd(v *viper.Viper) *cobra.Command {
@@ -74,6 +116,15 @@ func init() {
 	root.RootCmd.AddCommand(configureCmd)
 }
 
+// bindFlag is a small helper to keep flag declarations terse: registering a
+// pflag and binding it to viper is always the same two-line ritual. Callers
+// that need a non-zero default that won't already be set via SetViperDefaults
+// (e.g. fields whose struct lacks a `default:` tag) should additionally call
+// v.SetDefault — see the self_monitoring/host_monitoring blocks below.
+func bindFlag(cmd *cobra.Command, v *viper.Viper, name string) {
+	v.BindPFlag(name, cmd.PersistentFlags().Lookup(name))
+}
+
 func RegisterConfigFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().StringVarP(&config_path, "config_path", "", "", "Path to write config output file to")
 	cmd.Flags().Bool("print", false, "Print the configuration to stdout instead of writing to a file")
@@ -81,57 +132,156 @@ func RegisterConfigFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().Bool("include-defaults", false, "Include the names and default values for unset config options.")
 	v.BindPFlag("include-defaults", cmd.Flags().Lookup("include-defaults"))
 
+	// ---- Top-level ----
+
 	cmd.PersistentFlags().StringVar(&token, "token", "", "Observe token")
-	v.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
+	bindFlag(cmd, v, "token")
 
 	cmd.PersistentFlags().StringVar(&observe_url, "observe_url", "", "Observe data collection url")
-	v.BindPFlag("observe_url", cmd.PersistentFlags().Lookup("observe_url"))
+	bindFlag(cmd, v, "observe_url")
 
 	cmd.PersistentFlags().StringSliceVar(&cloud_resource_detectors, "cloud_resource_detectors", []string{}, "The cloud environments from which to detect resources")
-	v.BindPFlag("cloud_resource_detectors", cmd.PersistentFlags().Lookup("cloud_resource_detectors"))
+	bindFlag(cmd, v, "cloud_resource_detectors")
 
-	cmd.PersistentFlags().StringToStringVar(&resource_attributes, "resource_attributes", map[string]string{}, "The cloud environments from which to detect resources")
-	v.BindPFlag("resource_attributes", cmd.PersistentFlags().Lookup("resource_attributes"))
+	cmd.PersistentFlags().StringToStringVar(&attributes, "attributes", map[string]string{}, "Global telemetry attributes (key=value, comma-separated). Distinct from resource_attributes — these are applied at the telemetry-record level.")
+	bindFlag(cmd, v, "attributes")
+
+	cmd.PersistentFlags().StringToStringVar(&resource_attributes, "resource_attributes", map[string]string{}, "Global resource attributes (key=value, comma-separated). Applied at the OTel resource level.")
+	bindFlag(cmd, v, "resource_attributes")
+
+	cmd.PersistentFlags().BoolVar(&omit_base_components, "omit_base_components", false, "Skip emitting the bundled base OTel pipeline components (advanced; only set if you know you need it)")
+	bindFlag(cmd, v, "omit_base_components")
+
+	cmd.PersistentFlags().StringVar(&agent_local_file_path, "agent_local_file_path", "", "Path the agent uses for local-file persistence (advanced)")
+	bindFlag(cmd, v, "agent_local_file_path")
+
+	// ---- application.RED_metrics ----
 
 	cmd.PersistentFlags().BoolVar(&application_RED_metrics_enabled, "application::RED_metrics::enabled", false, "Enable RED metrics generation for application traces")
-	v.BindPFlag("application::RED_metrics::enabled", cmd.PersistentFlags().Lookup("application::RED_metrics::enabled"))
+	bindFlag(cmd, v, "application::RED_metrics::enabled")
+
+	cmd.PersistentFlags().BoolVar(&application_RED_metrics_only_generate_for_service_entrypoint_spans, "application::RED_metrics::only_generate_for_service_entrypoint_spans", false, "When generating RED metrics, skip spans that are not service entrypoint spans (kind Server / Consumer or DB/messaging client calls)")
+	bindFlag(cmd, v, "application::RED_metrics::only_generate_for_service_entrypoint_spans")
+
+	cmd.PersistentFlags().StringSliceVar(&application_RED_metrics_resource_dimensions, "application::RED_metrics::resource_dimensions", nil, "Resource attributes to include as RED metric dimensions (defaults to service.namespace, service.version, deployment.environment)")
+	bindFlag(cmd, v, "application::RED_metrics::resource_dimensions")
+
+	cmd.PersistentFlags().StringSliceVar(&application_RED_metrics_span_dimensions, "application::RED_metrics::span_dimensions", nil, "Span attributes to include as RED metric dimensions (defaults to peer.db.name, peer.messaging.system, otel.status_description, observe.status_code)")
+	bindFlag(cmd, v, "application::RED_metrics::span_dimensions")
+
+	// ---- health_check ----
+
+	cmd.PersistentFlags().BoolVar(&health_check_enabled, "health_check::enabled", true, "Enable the agent health-check HTTP endpoint")
+	bindFlag(cmd, v, "health_check::enabled")
+
+	cmd.PersistentFlags().StringVar(&health_check_endpoint, "health_check::endpoint", "localhost:13133", "Address the health-check endpoint binds to")
+	bindFlag(cmd, v, "health_check::endpoint")
+
+	cmd.PersistentFlags().StringVar(&health_check_path, "health_check::path", "/status", "HTTP path the health-check endpoint serves")
+	bindFlag(cmd, v, "health_check::path")
+
+	// ---- forwarding ----
+
+	cmd.PersistentFlags().BoolVar(&forwarding_enabled, "forwarding::enabled", true, "Enable the OTLP receivers for forwarding application telemetry through the agent")
+	bindFlag(cmd, v, "forwarding::enabled")
+
+	cmd.PersistentFlags().StringVar(&forwarding_endpoints_http, "forwarding::endpoints::http", "localhost:4318", "Address the OTLP HTTP receiver binds to")
+	bindFlag(cmd, v, "forwarding::endpoints::http")
+
+	cmd.PersistentFlags().StringVar(&forwarding_endpoints_grpc, "forwarding::endpoints::grpc", "localhost:4317", "Address the OTLP gRPC receiver binds to")
+	bindFlag(cmd, v, "forwarding::endpoints::grpc")
 
 	cmd.PersistentFlags().StringVar(&forwarding_metrics_format, "forwarding::metrics::output_format", "", "Format for sending app metrics to Observe, valid options are 'prometheus' and 'otel'")
-	v.BindPFlag("forwarding::metrics::output_format", cmd.PersistentFlags().Lookup("forwarding::metrics::output_format"))
+	bindFlag(cmd, v, "forwarding::metrics::output_format")
+
+	cmd.PersistentFlags().BoolVar(&forwarding_metrics_convert_cumulative_to_delta, "forwarding::metrics::convert_cumulative_to_delta", false, "Convert cumulative metrics to delta before forwarding (only valid when output_format=otel)")
+	bindFlag(cmd, v, "forwarding::metrics::convert_cumulative_to_delta")
+
+	cmd.PersistentFlags().StringVar(&forwarding_traces_max_span_duration, "forwarding::traces::max_span_duration", "1h", "Drop spans whose duration exceeds this value (e.g. '1h', '15m', or 'none' to disable)")
+	bindFlag(cmd, v, "forwarding::traces::max_span_duration")
+
+	// ---- internal_telemetry ----
+
+	cmd.PersistentFlags().BoolVar(&internal_telemetry_enabled, "internal_telemetry::enabled", true, "Enable internal telemetry (the agent observing itself)")
+	bindFlag(cmd, v, "internal_telemetry::enabled")
+
+	cmd.PersistentFlags().BoolVar(&internal_telemetry_metrics_enabled, "internal_telemetry::metrics::enabled", true, "Enable internal Prometheus metrics about the agent's own pipelines")
+	bindFlag(cmd, v, "internal_telemetry::metrics::enabled")
+
+	cmd.PersistentFlags().StringVar(&internal_telemetry_metrics_host, "internal_telemetry::metrics::host", "localhost", "Host the internal-telemetry metrics endpoint binds to")
+	bindFlag(cmd, v, "internal_telemetry::metrics::host")
+
+	cmd.PersistentFlags().IntVar(&internal_telemetry_metrics_port, "internal_telemetry::metrics::port", 8888, "Port the internal-telemetry metrics endpoint binds to")
+	bindFlag(cmd, v, "internal_telemetry::metrics::port")
+
+	cmd.PersistentFlags().StringVar(&internal_telemetry_metrics_level, "internal_telemetry::metrics::level", "detailed", "Internal telemetry verbosity level (basic / normal / detailed)")
+	bindFlag(cmd, v, "internal_telemetry::metrics::level")
+
+	cmd.PersistentFlags().BoolVar(&internal_telemetry_logs_enabled, "internal_telemetry::logs::enabled", true, "Enable the agent's own log output")
+	bindFlag(cmd, v, "internal_telemetry::logs::enabled")
+
+	cmd.PersistentFlags().StringVar(&internal_telemetry_logs_level, "internal_telemetry::logs::level", "${env:OTEL_LOG_LEVEL}", "Agent log level (debug, info, warn, error). Defaults to the OTEL_LOG_LEVEL env var.")
+	bindFlag(cmd, v, "internal_telemetry::logs::level")
+
+	cmd.PersistentFlags().StringVar(&internal_telemetry_logs_encoding, "internal_telemetry::logs::encoding", "console", "Agent log encoding ('console' or 'json')")
+	bindFlag(cmd, v, "internal_telemetry::logs::encoding")
+
+	// ---- self_monitoring ----
 
 	cmd.PersistentFlags().BoolVar(&self_monitoring_enabled, "self_monitoring::enabled", true, "Enable self monitoring")
-	v.BindPFlag("self_monitoring::enabled", cmd.PersistentFlags().Lookup("self_monitoring::enabled"))
+	bindFlag(cmd, v, "self_monitoring::enabled")
 	v.SetDefault("self_monitoring::enabled", true)
 
 	cmd.PersistentFlags().BoolVar(&self_monitoring_fleet_enabled, "self_monitoring::fleet::enabled", true, "Enable fleet heartbeat")
-	v.BindPFlag("self_monitoring::fleet::enabled", cmd.PersistentFlags().Lookup("self_monitoring::fleet::enabled"))
+	bindFlag(cmd, v, "self_monitoring::fleet::enabled")
+	// Without this SetDefault, viper.Unmarshal returns the SetViperDefaults value
+	// (zero — false) instead of the cobra default, silently disabling fleet
+	// heartbeats whenever the flag isn't passed explicitly. Matches the pattern
+	// used for self_monitoring::enabled and the host_monitoring flags.
+	v.SetDefault("self_monitoring::fleet::enabled", true)
 
 	cmd.PersistentFlags().StringVar(&self_monitoring_fleet_interval, "self_monitoring::fleet::interval", "", "Fleet heartbeat interval (e.g., '5m', '1h')")
-	v.BindPFlag("self_monitoring::fleet::interval", cmd.PersistentFlags().Lookup("self_monitoring::fleet::interval"))
+	bindFlag(cmd, v, "self_monitoring::fleet::interval")
 
 	cmd.PersistentFlags().StringVar(&self_monitoring_fleet_config_interval, "self_monitoring::fleet::config_interval", "", "Fleet config heartbeat interval (e.g., '30m', '24h')")
-	v.BindPFlag("self_monitoring::fleet::config_interval", cmd.PersistentFlags().Lookup("self_monitoring::fleet::config_interval"))
+	bindFlag(cmd, v, "self_monitoring::fleet::config_interval")
+
+	// ---- host_monitoring ----
 
 	cmd.PersistentFlags().BoolVar(&host_monitoring_enabled, "host_monitoring::enabled", true, "Enable host monitoring")
-	v.BindPFlag("host_monitoring::enabled", cmd.PersistentFlags().Lookup("host_monitoring::enabled"))
+	bindFlag(cmd, v, "host_monitoring::enabled")
 	v.SetDefault("host_monitoring::enabled", true)
 
 	cmd.PersistentFlags().BoolVar(&host_monitoring_logs_enabled, "host_monitoring::logs::enabled", true, "Enable host monitoring logs")
-	v.BindPFlag("host_monitoring::logs::enabled", cmd.PersistentFlags().Lookup("host_monitoring::logs::enabled"))
+	bindFlag(cmd, v, "host_monitoring::logs::enabled")
 	v.SetDefault("host_monitoring::logs::enabled", true)
 
 	cmd.PersistentFlags().StringSliceVar(&host_monitoring_logs_include, "host_monitoring::logs::include", nil, "Set host monitoring log include paths")
-	v.BindPFlag("host_monitoring::logs::include", cmd.PersistentFlags().Lookup("host_monitoring::logs::include"))
+	bindFlag(cmd, v, "host_monitoring::logs::include")
+
+	cmd.PersistentFlags().StringSliceVar(&host_monitoring_logs_exclude, "host_monitoring::logs::exclude", nil, "Host monitoring log paths to exclude (applied after include)")
+	bindFlag(cmd, v, "host_monitoring::logs::exclude")
 
 	cmd.PersistentFlags().BoolVar(&host_monitoring_logs_auto_multiline_detection, "host_monitoring::logs::auto_multiline_detection", false, "Enable host monitoring log auto multiline detection")
-	v.BindPFlag("host_monitoring::logs::auto_multiline_detection", cmd.PersistentFlags().Lookup("host_monitoring::logs::auto_multiline_detection"))
+	bindFlag(cmd, v, "host_monitoring::logs::auto_multiline_detection")
 	v.SetDefault("host_monitoring::logs::auto_multiline_detection", false)
 
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_host_enabled, "host_monitoring::metrics::host::enabled", true, "Enable host monitoring host metrics")
-	v.BindPFlag("host_monitoring::metrics::host::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::host::enabled"))
+	bindFlag(cmd, v, "host_monitoring::metrics::host::enabled")
 	v.SetDefault("host_monitoring::metrics::host::enabled", true)
 
 	cmd.PersistentFlags().BoolVar(&host_monitoring_metrics_process_enabled, "host_monitoring::metrics::process::enabled", false, "Enable host monitoring process metrics")
-	v.BindPFlag("host_monitoring::metrics::process::enabled", cmd.PersistentFlags().Lookup("host_monitoring::metrics::process::enabled"))
+	bindFlag(cmd, v, "host_monitoring::metrics::process::enabled")
 	v.SetDefault("host_monitoring::metrics::process::enabled", false)
+
+	// ---- exporters ----
+
+	cmd.PersistentFlags().BoolVar(&exporters_sending_queue_batch_enabled, "exporters::sending_queue_batch::enabled", false, "Enable batching at the OTel exporter sending queue (advanced)")
+	bindFlag(cmd, v, "exporters::sending_queue_batch::enabled")
+
+	cmd.PersistentFlags().IntVar(&exporters_sending_queue_batch_max_size, "exporters::sending_queue_batch::max_size", 41943040, "Max batch size in bytes for the exporter sending queue")
+	bindFlag(cmd, v, "exporters::sending_queue_batch::max_size")
+
+	cmd.PersistentFlags().BoolVar(&exporters_emit_prometheus_target_info_metric, "exporters::emit_prometheus_target_info_metric", false, "Emit the synthetic 'target_info' metric when exporting Prometheus")
+	bindFlag(cmd, v, "exporters::emit_prometheus_target_info_metric")
 }

--- a/internal/commands/initconfig/initconfig_test.go
+++ b/internal/commands/initconfig/initconfig_test.go
@@ -33,6 +33,9 @@ func Test_InitConfigCommand(t *testing.T) {
 				ObserveURL: "test-url",
 				SelfMonitoring: config.SelfMonitoringConfig{
 					Enabled: true,
+					Fleet: config.FleetHeartbeatConfig{
+						Enabled: true,
+					},
 				},
 				HostMonitoring: config.HostMonitoringConfig{
 					Enabled: true,
@@ -53,7 +56,7 @@ func Test_InitConfigCommand(t *testing.T) {
 			expectErr: "",
 		},
 		{
-			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url", "--self_monitoring::enabled=false", "--host_monitoring::enabled=false", "--host_monitoring::logs::enabled=false", "--host_monitoring::metrics::host::enabled=false", "--host_monitoring::metrics::process::enabled=false"},
+			args: []string{"--config_path=./test-config.yaml", "--token=test-token", "--observe_url=test-url", "--self_monitoring::enabled=false", "--self_monitoring::fleet::enabled=false", "--host_monitoring::enabled=false", "--host_monitoring::logs::enabled=false", "--host_monitoring::metrics::host::enabled=false", "--host_monitoring::metrics::process::enabled=false"},
 			expectedConfig: setConfigDefaults(config.AgentConfig{
 				Token:      "test-token",
 				ObserveURL: "test-url",
@@ -86,6 +89,9 @@ func Test_InitConfigCommand(t *testing.T) {
 				},
 				SelfMonitoring: config.SelfMonitoringConfig{
 					Enabled: true,
+					Fleet: config.FleetHeartbeatConfig{
+						Enabled: true,
+					},
 				},
 				HostMonitoring: config.HostMonitoringConfig{
 					Enabled: true,
@@ -128,6 +134,117 @@ func Test_InitConfigCommand(t *testing.T) {
 			}),
 			expectErr: "",
 		},
+		// Exercise the newly-added flags from the init-config-flags PR. This
+		// covers every section that previously had no CLI surface so the
+		// matrix of "did we wire this up correctly?" stays answerable.
+		//
+		// Note: this test case only exercises fields whose default is the Go
+		// zero value (false / "" / nil). Default-true bools (e.g.
+		// internal_telemetry::*::enabled, health_check::enabled,
+		// forwarding::enabled) need a different test setup because
+		// setConfigDefaults — go-defaults — will re-apply schema defaults
+		// over any false we set explicitly, so we can't assert that the
+		// flag flipped them. They get their own test below.
+		{
+			args: []string{
+				"--config_path=./test-config.yaml",
+				"--token=test-token",
+				"--observe_url=test-url",
+				"--omit_base_components=true",
+				"--agent_local_file_path=/var/lib/observe-agent",
+				"--attributes=team=platform,deployment.environment=staging",
+				"--application::RED_metrics::enabled=true",
+				"--application::RED_metrics::only_generate_for_service_entrypoint_spans=true",
+				"--application::RED_metrics::resource_dimensions=service.namespace,service.version",
+				"--application::RED_metrics::span_dimensions=peer.db.name,otel.status_description",
+				"--health_check::endpoint=0.0.0.0:13133",
+				"--health_check::path=/healthz",
+				"--forwarding::endpoints::http=0.0.0.0:4318",
+				"--forwarding::endpoints::grpc=0.0.0.0:4317",
+				"--forwarding::metrics::convert_cumulative_to_delta=true",
+				"--forwarding::traces::max_span_duration=30m",
+				"--internal_telemetry::metrics::host=0.0.0.0",
+				"--internal_telemetry::metrics::port=9999",
+				"--internal_telemetry::metrics::level=basic",
+				"--internal_telemetry::logs::level=debug",
+				"--internal_telemetry::logs::encoding=json",
+				"--host_monitoring::logs::exclude=/var/log/btmp,/var/log/wtmp",
+				"--exporters::sending_queue_batch::enabled=true",
+				"--exporters::sending_queue_batch::max_size=1048576",
+				"--exporters::emit_prometheus_target_info_metric=true",
+			},
+			expectedConfig: setConfigDefaults(config.AgentConfig{
+				Token:              "test-token",
+				ObserveURL:         "test-url",
+				OmitBaseComponents: true,
+				AgentLocalFilePath: "/var/lib/observe-agent",
+				Attributes: map[string]string{
+					"team":                   "platform",
+					"deployment.environment": "staging",
+				},
+				Application: config.ApplicationConfig{
+					REDMetrics: config.REDMetricsConfig{
+						Enabled:                               true,
+						OnlyGenerateForServiceEntrypointSpans: true,
+						ResourceDimensions:                    []string{"service.namespace", "service.version"},
+						SpanDimensions:                        []string{"peer.db.name", "otel.status_description"},
+					},
+				},
+				HealthCheck: config.HealthCheckConfig{
+					Endpoint: "0.0.0.0:13133",
+					Path:     "/healthz",
+				},
+				Forwarding: config.ForwardingConfig{
+					Endpoints: config.ForwardingReceiverEndpointsConfig{
+						HTTP: "0.0.0.0:4318",
+						GRPC: "0.0.0.0:4317",
+					},
+					Metrics: config.ForwardingMetricsConfig{
+						ConvertCumulativeToDelta: true,
+					},
+					Traces: config.ForwardingTracesConfig{
+						MaxSpanDuration: "30m",
+					},
+				},
+				InternalTelemetry: config.InternalTelemetryConfig{
+					Metrics: config.InternalTelemetryMetricsConfig{
+						Host:  "0.0.0.0",
+						Port:  9999,
+						Level: "basic",
+					},
+					Logs: config.InternalTelemetryLogsConfig{
+						Level:    "debug",
+						Encoding: "json",
+					},
+				},
+				SelfMonitoring: config.SelfMonitoringConfig{
+					Enabled: true,
+					Fleet: config.FleetHeartbeatConfig{
+						Enabled: true,
+					},
+				},
+				HostMonitoring: config.HostMonitoringConfig{
+					Enabled: true,
+					Logs: config.HostMonitoringLogsConfig{
+						Enabled: true,
+						Exclude: []string{"/var/log/btmp", "/var/log/wtmp"},
+					},
+					Metrics: config.HostMonitoringMetricsConfig{
+						Host: config.HostMonitoringHostMetricsConfig{
+							Enabled: true,
+						},
+					},
+				},
+				Exporters: config.ExportersConfig{
+					SendingQueueBatch: config.SendingQueueBatchConfig{
+						Enabled: true,
+						MaxSize: 1048576,
+					},
+					EmitPrometheusTargetInfoMetric: true,
+				},
+			}),
+			expectErr: "",
+		},
 	}
 	for _, tc := range testcases {
 		v := viper.NewWithOptions(viper.KeyDelimiter("::"))
@@ -166,4 +283,65 @@ func Test_InitConfigCommand(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedConfig, configYaml)
 	}
+}
+
+// Asserts that --flag=false flips the value for fields whose schema default is
+// true. The main test above uses setConfigDefaults() to build expected configs,
+// which calls go-defaults — and go-defaults treats `false` as a zero value and
+// re-applies the schema's `default:"true"`, hiding the flip from the assertion.
+// So we read the YAML directly and string-match here instead of round-tripping
+// through AgentConfig.
+func Test_InitConfigCommand_DefaultTrueBoolsCanBeFlippedToFalse(t *testing.T) {
+	t.Cleanup(func() {
+		os.Remove("./test-config.yaml")
+	})
+
+	args := []string{
+		"--config_path=./test-config.yaml",
+		"--token=test-token",
+		"--observe_url=test-url",
+		"--health_check::enabled=false",
+		"--forwarding::enabled=false",
+		"--internal_telemetry::enabled=false",
+		"--internal_telemetry::metrics::enabled=false",
+		"--internal_telemetry::logs::enabled=false",
+	}
+
+	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
+	config.SetViperDefaults(v, "::", "")
+	cmd := NewConfigureCmd(v)
+	RegisterConfigFlags(cmd, v)
+	cmd.SetArgs(args)
+	assert.NoError(t, cmd.Execute())
+
+	contents, err := os.ReadFile("./test-config.yaml")
+	assert.NoError(t, err)
+	yamlStr := string(contents)
+
+	// Each of these sections should contain the explicit `enabled: false` we
+	// set via flag, not the schema default of true. Match scoped to each
+	// section's heading so we don't false-positive on an `enabled: false`
+	// from elsewhere in the file. Indentation-agnostic — yaml.Marshal can
+	// emit 2- or 4-space; the writeConfigFile path currently emits 4.
+	for _, section := range []string{
+		"health_check",
+		"forwarding",
+		"internal_telemetry",
+	} {
+		assert.Regexp(t,
+			`(?ms)^`+section+`:\n(.*\n)*?\s+enabled: false`,
+			yamlStr,
+			"%s.enabled should be flipped to false by --%s::enabled=false", section, section)
+	}
+
+	// internal_telemetry.metrics.enabled and .logs.enabled are nested another
+	// level deeper.
+	assert.Regexp(t,
+		`(?ms)^internal_telemetry:\n(.*\n)*?\s+metrics:\n(.*\n)*?\s+enabled: false`,
+		yamlStr,
+		"internal_telemetry.metrics.enabled should be flipped to false")
+	assert.Regexp(t,
+		`(?ms)^internal_telemetry:\n(.*\n)*?\s+logs:\n(.*\n)*?\s+enabled: false`,
+		yamlStr,
+		"internal_telemetry.logs.enabled should be flipped to false")
 }


### PR DESCRIPTION
## Summary

`init-config` previously exposed CLI flags for ~13 of the ~37 leaf fields in
`AgentConfig`. Anything else (health check, forwarding endpoints, internal
telemetry, exporter batching, etc.) required hand-editing
`/etc/observe-agent/observe-agent.yaml` — making the CLI awkward to drive from
automation (agent skills, runbooks, fleet tooling) and unobvious to users who
don't read the schema.

This PR adds flags for all remaining sections and also fixes a pre-existing
silent-default bug for `--self_monitoring::fleet::enabled`.

### New flags (24)

- **top-level:** `--omit_base_components`, `--attributes` (record-level, distinct from `--resource_attributes`), `--agent_local_file_path`
- **application::RED_metrics:** `--only_generate_for_service_entrypoint_spans`, `--resource_dimensions`, `--span_dimensions`
- **health_check:** `--enabled`, `--endpoint`, `--path`
- **forwarding:** `--enabled`, `--endpoints::http`, `--endpoints::grpc`, `--metrics::convert_cumulative_to_delta`, `--traces::max_span_duration`
- **internal_telemetry:** `--enabled`, `--metrics::{enabled,host,port,level}`, `--logs::{enabled,level,encoding}`
- **host_monitoring::logs::exclude**
- **exporters:** `--sending_queue_batch::{enabled,max_size}`, `--emit_prometheus_target_info_metric`

### Bug fix: `self_monitoring::fleet::enabled` was silently `false` despite cobra default `true`

The flag was registered with cobra default `true` and `BindPFlag`, but lacked a
`v.SetDefault` call. Compare to the adjacent `self_monitoring::enabled` block
which has both. When `init-config` is run without passing the flag,
`viper.Unmarshal` returns the value from `SetViperDefaults` (the Go zero value:
`false`) rather than the cobra default — so the written config has
`fleet.enabled: false` and fleet heartbeats are silently disabled. Discovered
during end-to-end testing where a freshly-installed agent didn't appear in
Fleet Management until we passed `--self_monitoring::fleet::enabled=true`
explicitly.

This PR adds the missing `v.SetDefault("self_monitoring::fleet::enabled", true)`
to match the pattern used for the other Bool flags whose schema lacks a
`default:` tag.

### Refactor

Adds a small `bindFlag(cmd, v, name)` helper that wraps the
`v.BindPFlag(name, cmd.PersistentFlags().Lookup(name))` ritual. Every existing
flag was a two-line dance; the helper keeps the file as a flat list of
declarations and reduces the boilerplate per flag from 2 lines to 1.

## Test plan

- [x] Existing test `Test_InitConfigCommand` updated to reflect the fleet bug fix (cases that didn't explicitly set fleet now expect `Fleet.Enabled=true`).
- [x] Added a new test case to `Test_InitConfigCommand` exercising all new flags whose default is the Go zero value (these play well with `setConfigDefaults` / go-defaults).
- [x] Added `Test_InitConfigCommand_DefaultTrueBoolsCanBeFlippedToFalse` which uses direct YAML regex inspection to verify default-true bools (`health_check::enabled`, `forwarding::enabled`, `internal_telemetry::*::enabled`) actually flip to `false` when the flag is passed. Round-tripping through `AgentConfig` doesn't work for this case because go-defaults treats `false` as a zero value and re-applies the schema's `default:"true"`, hiding the flag-flip from struct-equality assertions.
- [x] `go test ./internal/commands/initconfig/...` passes locally.
- [x] `go build ./...` is clean.

## Followups (not in this PR)

- The struct-tag default mismatch is the root cause of needing per-flag `v.SetDefault` calls in init-config. The cleaner fix is to add `default:"true"` tags to the `Enabled` fields in `configschema.go` (`SelfMonitoringConfig`, `FleetHeartbeatConfig`, `HostMonitoringConfig`, etc.). That would let `defaults.SetDefaults` and viper agree without compensation in the init-config layer. Deliberately not touching the schema in this PR to keep the scope narrow.
- The PR-companion gap analysis ( https://github.com/observeinc/skills/blob/main/.../observe-agent-gaps.md ) notes deeper gaps in `diagnose` (no DNS check, no clock skew check, no fleet-pipeline check, etc.) and missing top-level commands (`config set`, `restart`, `uninstall`). Those are scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)