### PR TITLE
chore: support breaking changes in the changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,21 +91,24 @@ changelog:
       - "^docs:"
       - "^test:"
   groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    - title: "Breaking Changes"
+      regexp: '^.*?\w+(\([[:word:]]+\))?!:.+$'
       order: 0
-    - title: "Bug Fixes"
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??:.+$'
       order: 1
-    - title: "Configuration Updates"
-      regexp: '^.*?config(\([[:word:]]+\))??!?:.+$'
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??:.+$'
       order: 2
-    - title: "Enhancements"
-      regexp: '^.*?internal(\([[:word:]]+\))??!?:.+$'
+    - title: "Configuration Updates"
+      regexp: '^.*?config(\([[:word:]]+\))??:.+$'
       order: 3
-    - title: "Dependency Updates"
-      regexp: '^.*?build\(deps\)(\([[:word:]]+\))??!?:.+$'
+    - title: "Enhancements"
+      regexp: '^.*?internal(\([[:word:]]+\))??:.+$'
       order: 4
+    - title: "Dependency Updates"
+      regexp: '^.*?build\(deps\)(\([[:word:]]+\))??:.+$'
+      order: 5
     - title: Others
       order: 999
 


### PR DESCRIPTION
### Description

Adds a `Breaking Changes` group to the changelog. Also move respective `!`  commits to the new group so they are treated as breaking changes as per https://www.conventionalcommits.org/en/v1.0.0/#specification